### PR TITLE
Feature/ena2-7123_input_style_label_offset

### DIFF
--- a/packages/modul-components/src/components/address/address-autocomplete-field/__snapshots__/address-autocomplete-field.stories.ts.snap
+++ b/packages/modul-components/src/components/address/address-autocomplete-field/__snapshots__/address-autocomplete-field.stories.ts.snap
@@ -15,7 +15,7 @@ exports[`Storyshots components|/address/m-address-autocomplete-field default 1`]
         >
           <div
             class="m-input-style m--has-cursor-pointer m--has-label m--is-tag-default"
-            style="width: 100%; margin-top: 10px;"
+            style="width: 100%;"
           >
             <div
               class="m-input-style__main"
@@ -26,7 +26,6 @@ exports[`Storyshots components|/address/m-address-autocomplete-field default 1`]
                 <label
                   class="m-input-style__label"
                   for="mDropdown-uuid"
-                  style="margin-right: 0px;"
                 >
                   <span
                     class="m-input-style__text"

--- a/packages/modul-components/src/components/address/address-editor/__snapshots__/address-editor.stories.ts.snap
+++ b/packages/modul-components/src/components/address/address-editor/__snapshots__/address-editor.stories.ts.snap
@@ -12,7 +12,6 @@ exports[`Storyshots components|/address/m-address-editor default 1`] = `
       >
         <div
           class="m-input-style m--is-label-up m--has-label m--has-value m--is-tag-default"
-          style="margin-top: 10px;"
         >
           <div
             class="m-input-style__main"
@@ -23,7 +22,6 @@ exports[`Storyshots components|/address/m-address-editor default 1`] = `
               <label
                 class="m-input-style__label"
                 for="mTextfield-uuid"
-                style="margin-right: 0px;"
               >
                 <span
                   class="m-input-style__text"
@@ -94,7 +92,6 @@ exports[`Storyshots components|/address/m-address-editor default 1`] = `
       >
         <div
           class="m-input-style m--has-label m--is-tag-default"
-          style="margin-top: 10px;"
         >
           <div
             class="m-input-style__main"
@@ -105,7 +102,6 @@ exports[`Storyshots components|/address/m-address-editor default 1`] = `
               <label
                 class="m-input-style__label"
                 for="mTextfield-uuid"
-                style="margin-right: 0px;"
               >
                 <span
                   class="m-input-style__text"
@@ -176,7 +172,6 @@ exports[`Storyshots components|/address/m-address-editor default 1`] = `
       >
         <div
           class="m-input-style m--is-label-up m--has-label m--has-value m--is-tag-default"
-          style="margin-top: 10px;"
         >
           <div
             class="m-input-style__main"
@@ -187,7 +182,6 @@ exports[`Storyshots components|/address/m-address-editor default 1`] = `
               <label
                 class="m-input-style__label"
                 for="mTextfield-uuid"
-                style="margin-right: 0px;"
               >
                 <span
                   class="m-input-style__text"
@@ -258,7 +252,6 @@ exports[`Storyshots components|/address/m-address-editor default 1`] = `
       >
         <div
           class="m-input-style m--is-label-up m--has-label m--has-value m--is-tag-default"
-          style="margin-top: 10px;"
         >
           <div
             class="m-input-style__main"
@@ -269,7 +262,6 @@ exports[`Storyshots components|/address/m-address-editor default 1`] = `
               <label
                 class="m-input-style__label"
                 for="mTextfield-uuid"
-                style="margin-right: 0px;"
               >
                 <span
                   class="m-input-style__text"
@@ -340,7 +332,7 @@ exports[`Storyshots components|/address/m-address-editor default 1`] = `
       >
         <div
           class="m-input-style m--is-label-up m--has-cursor-pointer m--has-label m--has-value m--is-tag-default"
-          style="width: 100%; margin-top: 10px;"
+          style="width: 100%;"
         >
           <div
             class="m-input-style__main"
@@ -351,7 +343,6 @@ exports[`Storyshots components|/address/m-address-editor default 1`] = `
               <label
                 class="m-input-style__label"
                 for="mDropdown-uuid"
-                style="margin-right: 0px;"
               >
                 <span
                   class="m-input-style__text"
@@ -451,7 +442,6 @@ exports[`Storyshots components|/address/m-address-editor default 1`] = `
       >
         <div
           class="m-input-style m--is-label-up m--has-label m--has-value m--is-tag-default"
-          style="margin-top: 10px;"
         >
           <div
             class="m-input-style__main"
@@ -462,7 +452,6 @@ exports[`Storyshots components|/address/m-address-editor default 1`] = `
               <label
                 class="m-input-style__label"
                 for="mTextfield-uuid"
-                style="margin-right: 0px;"
               >
                 <span
                   class="m-input-style__text"
@@ -569,7 +558,6 @@ exports[`Storyshots components|/address/m-address-editor empty address 1`] = `
       >
         <div
           class="m-input-style m--has-label m--is-tag-default"
-          style="margin-top: 10px;"
         >
           <div
             class="m-input-style__main"
@@ -580,7 +568,6 @@ exports[`Storyshots components|/address/m-address-editor empty address 1`] = `
               <label
                 class="m-input-style__label"
                 for="mTextfield-uuid"
-                style="margin-right: 0px;"
               >
                 <span
                   class="m-input-style__text"
@@ -651,7 +638,6 @@ exports[`Storyshots components|/address/m-address-editor empty address 1`] = `
       >
         <div
           class="m-input-style m--has-label m--is-tag-default"
-          style="margin-top: 10px;"
         >
           <div
             class="m-input-style__main"
@@ -662,7 +648,6 @@ exports[`Storyshots components|/address/m-address-editor empty address 1`] = `
               <label
                 class="m-input-style__label"
                 for="mTextfield-uuid"
-                style="margin-right: 0px;"
               >
                 <span
                   class="m-input-style__text"
@@ -733,7 +718,6 @@ exports[`Storyshots components|/address/m-address-editor empty address 1`] = `
       >
         <div
           class="m-input-style m--has-label m--is-tag-default"
-          style="margin-top: 10px;"
         >
           <div
             class="m-input-style__main"
@@ -744,7 +728,6 @@ exports[`Storyshots components|/address/m-address-editor empty address 1`] = `
               <label
                 class="m-input-style__label"
                 for="mTextfield-uuid"
-                style="margin-right: 0px;"
               >
                 <span
                   class="m-input-style__text"
@@ -815,7 +798,6 @@ exports[`Storyshots components|/address/m-address-editor empty address 1`] = `
       >
         <div
           class="m-input-style m--has-label m--is-tag-default"
-          style="margin-top: 10px;"
         >
           <div
             class="m-input-style__main"
@@ -826,7 +808,6 @@ exports[`Storyshots components|/address/m-address-editor empty address 1`] = `
               <label
                 class="m-input-style__label"
                 for="mTextfield-uuid"
-                style="margin-right: 0px;"
               >
                 <span
                   class="m-input-style__text"
@@ -897,7 +878,7 @@ exports[`Storyshots components|/address/m-address-editor empty address 1`] = `
       >
         <div
           class="m-input-style m--is-label-up m--has-cursor-pointer m--has-label m--has-value m--is-tag-default"
-          style="width: 100%; margin-top: 10px;"
+          style="width: 100%;"
         >
           <div
             class="m-input-style__main"
@@ -908,7 +889,6 @@ exports[`Storyshots components|/address/m-address-editor empty address 1`] = `
               <label
                 class="m-input-style__label"
                 for="mDropdown-uuid"
-                style="margin-right: 0px;"
               >
                 <span
                   class="m-input-style__text"
@@ -1008,7 +988,6 @@ exports[`Storyshots components|/address/m-address-editor empty address 1`] = `
       >
         <div
           class="m-input-style m--has-label m--is-tag-default"
-          style="margin-top: 10px;"
         >
           <div
             class="m-input-style__main"
@@ -1019,7 +998,6 @@ exports[`Storyshots components|/address/m-address-editor empty address 1`] = `
               <label
                 class="m-input-style__label"
                 for="mTextfield-uuid"
-                style="margin-right: 0px;"
               >
                 <span
                   class="m-input-style__text"

--- a/packages/modul-components/src/components/copy-to-clipboard/__snapshots__/copy-to-clipboard.stories.ts.snap
+++ b/packages/modul-components/src/components/copy-to-clipboard/__snapshots__/copy-to-clipboard.stories.ts.snap
@@ -12,7 +12,6 @@ exports[`Storyshots components|m-copy-to-clipboard States 1`] = `
       >
         <div
           class="m-input-style m--is-readonly m--is-tag-default"
-          style="margin-top: 10px;"
         >
           <div
             class="m-input-style__main"
@@ -96,7 +95,6 @@ exports[`Storyshots components|m-copy-to-clipboard States 1`] = `
       >
         <div
           class="m-input-style m--is-readonly m--is-tag-default"
-          style="margin-top: 10px;"
         >
           <div
             class="m-input-style__main"
@@ -188,7 +186,6 @@ exports[`Storyshots components|m-copy-to-clipboard States 1`] = `
       >
         <div
           class="m-input-style m--is-waiting m--is-tag-default"
-          style="margin-top: 10px;"
         >
           <div
             class="m-input-style__main"
@@ -281,7 +278,6 @@ exports[`Storyshots components|m-copy-to-clipboard custom 1`] = `
     >
       <div
         class="m-input-style m--is-readonly m--is-label-up m--has-label m--has-value m--is-tag-default"
-        style="margin-top: 10px;"
       >
         <div
           class="m-input-style__main"
@@ -292,7 +288,6 @@ exports[`Storyshots components|m-copy-to-clipboard custom 1`] = `
             <label
               class="m-input-style__label"
               for="mTextfield-uuid"
-              style="margin-right: 0px;"
             >
               <span
                 class="m-input-style__text"
@@ -371,7 +366,6 @@ exports[`Storyshots components|m-copy-to-clipboard custom 1`] = `
     >
       <div
         class="m-input-style m--is-readonly m--has-value m--is-tag-default"
-        style="margin-top: 10px;"
       >
         <div
           class="m-input-style__main"
@@ -461,7 +455,6 @@ exports[`Storyshots components|m-copy-to-clipboard custom user feedback 1`] = `
   >
     <div
       class="m-input-style m--is-readonly m--has-value m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -552,7 +545,6 @@ exports[`Storyshots components|m-copy-to-clipboard default 1`] = `
   >
     <div
       class="m-input-style m--is-readonly m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -643,7 +635,6 @@ exports[`Storyshots components|m-copy-to-clipboard default with value 1`] = `
   >
     <div
       class="m-input-style m--is-readonly m--has-value m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -734,7 +725,6 @@ exports[`Storyshots components|m-copy-to-clipboard user feedback 1`] = `
   >
     <div
       class="m-input-style m--is-readonly m--has-value m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"

--- a/packages/modul-components/src/components/datepicker/__snapshots__/datepicker.stories.ts.snap
+++ b/packages/modul-components/src/components/datepicker/__snapshots__/datepicker.stories.ts.snap
@@ -8,7 +8,6 @@ exports[`Storyshots components|m-datepicker date big min and max limit 1`] = `
   >
     <div
       class="m-input-style m--has-value m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -119,7 +118,6 @@ exports[`Storyshots components|m-datepicker date format invalid 1`] = `
   >
     <div
       class="m-input-style m--has-error m--has-value m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -253,7 +251,6 @@ exports[`Storyshots components|m-datepicker date off limit  max 1`] = `
   >
     <div
       class="m-input-style m--has-error m--has-value m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -387,7 +384,6 @@ exports[`Storyshots components|m-datepicker date off limit min 1`] = `
   >
     <div
       class="m-input-style m--has-error m--has-value m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -520,7 +516,6 @@ exports[`Storyshots components|m-datepicker default 1`] = `
 >
   <div
     class="m-input-style m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -628,7 +623,6 @@ exports[`Storyshots components|m-datepicker disabled 1`] = `
 >
   <div
     class="m-input-style m--is-disabled m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -738,7 +732,6 @@ exports[`Storyshots components|m-datepicker error-message 1`] = `
 >
   <div
     class="m-input-style m--has-error m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -877,7 +870,6 @@ exports[`Storyshots components|m-datepicker events 1`] = `
   >
     <div
       class="m-input-style m--has-value m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -1048,7 +1040,6 @@ exports[`Storyshots components|m-datepicker helper-message 1`] = `
 >
   <div
     class="m-input-style m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -1160,7 +1151,6 @@ exports[`Storyshots components|m-datepicker hide-internal-error-message 1`] = `
 >
   <div
     class="m-input-style m--has-error m--has-value m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -1268,7 +1258,6 @@ exports[`Storyshots components|m-datepicker label 1`] = `
 >
   <div
     class="m-input-style m--has-label m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -1279,7 +1268,6 @@ exports[`Storyshots components|m-datepicker label 1`] = `
         <label
           class="m-input-style__label"
           for="mDatepicker-uuid"
-          style="margin-right: 0px;"
         >
           <span
             class="m-input-style__text"
@@ -1381,7 +1369,6 @@ exports[`Storyshots components|m-datepicker label-up 1`] = `
 >
   <div
     class="m-input-style m--is-label-up m--has-label m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -1392,7 +1379,6 @@ exports[`Storyshots components|m-datepicker label-up 1`] = `
         <label
           class="m-input-style__label"
           for="mDatepicker-uuid"
-          style="margin-right: 0px;"
         >
           <span
             class="m-input-style__text"
@@ -1516,7 +1502,6 @@ exports[`Storyshots components|m-datepicker min and max 1`] = `
   >
     <div
       class="m-input-style m--has-value m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -1689,7 +1674,6 @@ exports[`Storyshots components|m-datepicker placeholder 1`] = `
 >
   <div
     class="m-input-style m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -1797,7 +1781,6 @@ exports[`Storyshots components|m-datepicker readonly 1`] = `
 >
   <div
     class="m-input-style m--is-readonly m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -1907,7 +1890,6 @@ exports[`Storyshots components|m-datepicker required-marker 1`] = `
 >
   <div
     class="m-input-style m--has-label m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -1918,7 +1900,6 @@ exports[`Storyshots components|m-datepicker required-marker 1`] = `
         <label
           class="m-input-style__label"
           for="mDatepicker-uuid"
-          style="margin-right: 0px;"
         >
           <span
             class="m-input-style__text"
@@ -2025,7 +2006,6 @@ exports[`Storyshots components|m-datepicker skip-input-validation=true 1`] = `
   >
     <div
       class="m-input-style m--has-value m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -2135,7 +2115,6 @@ exports[`Storyshots components|m-datepicker valid 1`] = `
 >
   <div
     class="m-input-style m--is-valid m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -2243,7 +2222,6 @@ exports[`Storyshots components|m-datepicker waiting 1`] = `
 >
   <div
     class="m-input-style m--is-waiting m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -2359,7 +2337,6 @@ exports[`Storyshots components|m-datepicker/initial-view days 1`] = `
 >
   <div
     class="m-input-style m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -2467,7 +2444,6 @@ exports[`Storyshots components|m-datepicker/initial-view years-months 1`] = `
 >
   <div
     class="m-input-style m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -2579,7 +2555,6 @@ exports[`Storyshots components|m-datepicker/initial-view years-months-birthdate 
 >
   <div
     class="m-input-style m--has-label m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -2590,7 +2565,6 @@ exports[`Storyshots components|m-datepicker/initial-view years-months-birthdate 
         <label
           class="m-input-style__label"
           for="mDatepicker-uuid"
-          style="margin-right: 0px;"
         >
           <span
             class="m-input-style__text"
@@ -2696,7 +2670,6 @@ exports[`Storyshots components|m-datepicker/type full-date 1`] = `
 >
   <div
     class="m-input-style m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -2804,7 +2777,6 @@ exports[`Storyshots components|m-datepicker/type years-months 1`] = `
 >
   <div
     class="m-input-style m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"

--- a/packages/modul-components/src/components/decimalfield/__snapshots__/decimalfield.stories.ts.snap
+++ b/packages/modul-components/src/components/decimalfield/__snapshots__/decimalfield.stories.ts.snap
@@ -9,7 +9,6 @@ exports[`Storyshots components|m-decimalfield Basic 1`] = `
     >
       <div
         class="m-input-style m--is-tag-default"
-        style="margin-top: 10px;"
       >
         <div
           class="m-input-style__main"
@@ -82,7 +81,6 @@ exports[`Storyshots components|m-decimalfield Basic 1`] = `
     >
       <div
         class="m-input-style m--has-label m--is-tag-default"
-        style="margin-top: 10px;"
       >
         <div
           class="m-input-style__main"
@@ -93,7 +91,6 @@ exports[`Storyshots components|m-decimalfield Basic 1`] = `
             <label
               class="m-input-style__label"
               for="mDecimalfield-uuid"
-              style="margin-right: 0px;"
             >
               <span
                 class="m-input-style__text"
@@ -160,7 +157,6 @@ exports[`Storyshots components|m-decimalfield Basic 1`] = `
     >
       <div
         class="m-input-style m--has-label m--is-tag-default"
-        style="margin-top: 10px;"
       >
         <div
           class="m-input-style__main"
@@ -171,7 +167,6 @@ exports[`Storyshots components|m-decimalfield Basic 1`] = `
             <label
               class="m-input-style__label"
               for="mDecimalfield-uuid"
-              style="margin-right: 0px;"
             >
               <span
                 class="m-input-style__text"
@@ -242,7 +237,6 @@ exports[`Storyshots components|m-decimalfield Basic 1`] = `
     >
       <div
         class="m-input-style m--is-valid m--is-tag-default"
-        style="margin-top: 10px;"
       >
         <div
           class="m-input-style__main"
@@ -338,7 +332,6 @@ exports[`Storyshots components|m-decimalfield Basic 1`] = `
     >
       <div
         class="m-input-style m--is-tag-default"
-        style="margin-top: 10px;"
       >
         <div
           class="m-input-style__main"
@@ -415,7 +408,6 @@ exports[`Storyshots components|m-decimalfield Basic 1`] = `
     >
       <div
         class="m-input-style m--has-error m--is-tag-default"
-        style="margin-top: 10px;"
       >
         <div
           class="m-input-style__main"
@@ -511,7 +503,6 @@ exports[`Storyshots components|m-decimalfield Basic 1`] = `
     >
       <div
         class="m-input-style m--is-label-up m--has-label m--is-tag-default"
-        style="margin-top: 10px;"
       >
         <div
           class="m-input-style__main"
@@ -522,7 +513,6 @@ exports[`Storyshots components|m-decimalfield Basic 1`] = `
             <label
               class="m-input-style__label"
               for="mDecimalfield-uuid"
-              style="margin-right: 0px;"
             >
               <span
                 class="m-input-style__text"
@@ -592,7 +582,6 @@ exports[`Storyshots components|m-decimalfield Custom precision 1`] = `
 >
   <div
     class="m-input-style m--has-value m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -665,7 +654,6 @@ exports[`Storyshots components|m-decimalfield Default precision 1`] = `
 >
   <div
     class="m-input-style m--has-value m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -738,7 +726,6 @@ exports[`Storyshots components|m-decimalfield Localization 1`] = `
 >
   <div
     class="m-input-style m--has-value m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -813,7 +800,6 @@ exports[`Storyshots components|m-decimalfield States 1`] = `
     >
       <div
         class="m-input-style m--is-disabled m--is-tag-default"
-        style="margin-top: 10px;"
       >
         <div
           class="m-input-style__main"
@@ -888,7 +874,6 @@ exports[`Storyshots components|m-decimalfield States 1`] = `
     >
       <div
         class="m-input-style m--is-readonly m--is-tag-default"
-        style="margin-top: 10px;"
       >
         <div
           class="m-input-style__main"
@@ -963,7 +948,6 @@ exports[`Storyshots components|m-decimalfield States 1`] = `
     >
       <div
         class="m-input-style m--is-waiting m--is-tag-default"
-        style="margin-top: 10px;"
       >
         <div
           class="m-input-style__main"
@@ -1046,7 +1030,6 @@ exports[`Storyshots components|m-decimalfield With initial value (0) 1`] = `
 >
   <div
     class="m-input-style m--has-value m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -1119,7 +1102,6 @@ exports[`Storyshots components|m-decimalfield With initial value 1`] = `
 >
   <div
     class="m-input-style m--has-value m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"

--- a/packages/modul-components/src/components/dropdown/__snapshots__/dropdown.stories.ts.snap
+++ b/packages/modul-components/src/components/dropdown/__snapshots__/dropdown.stories.ts.snap
@@ -7,7 +7,7 @@ exports[`Storyshots components|m-dropdown default 1`] = `
 >
   <div
     class="m-input-style m--has-cursor-pointer m--has-label m--is-tag-default"
-    style="width: 100%; margin-top: 10px;"
+    style="width: 100%;"
   >
     <div
       class="m-input-style__main"
@@ -18,7 +18,6 @@ exports[`Storyshots components|m-dropdown default 1`] = `
         <label
           class="m-input-style__label"
           for="mDropdown-uuid"
-          style="margin-right: 0px;"
         >
           <span
             class="m-input-style__text"
@@ -117,7 +116,7 @@ exports[`Storyshots components|m-dropdown focus 1`] = `
 >
   <div
     class="m-input-style m--has-cursor-pointer m--has-label m--is-tag-default"
-    style="width: 100%; margin-top: 10px;"
+    style="width: 100%;"
   >
     <div
       class="m-input-style__main"
@@ -128,7 +127,6 @@ exports[`Storyshots components|m-dropdown focus 1`] = `
         <label
           class="m-input-style__label"
           for="mDropdown-uuid"
-          style="margin-right: 0px;"
         >
           <span
             class="m-input-style__text"
@@ -227,7 +225,7 @@ exports[`Storyshots components|m-dropdown label-up 1`] = `
 >
   <div
     class="m-input-style m--is-label-up m--has-cursor-pointer m--has-label m--is-tag-default"
-    style="width: 100%; margin-top: 10px;"
+    style="width: 100%;"
   >
     <div
       class="m-input-style__main"
@@ -238,7 +236,6 @@ exports[`Storyshots components|m-dropdown label-up 1`] = `
         <label
           class="m-input-style__label"
           for="mDropdown-uuid"
-          style="margin-right: 0px;"
         >
           <span
             class="m-input-style__text"
@@ -345,7 +342,7 @@ exports[`Storyshots components|m-dropdown/disabled Item selected, with label 1`]
   >
     <div
       class="m-input-style m--is-label-up m--is-disabled m--has-label m--has-value m--is-tag-default"
-      style="width: 100%; margin-top: 10px;"
+      style="width: 100%;"
     >
       <div
         class="m-input-style__main"
@@ -356,7 +353,6 @@ exports[`Storyshots components|m-dropdown/disabled Item selected, with label 1`]
           <label
             class="m-input-style__label"
             for="mDropdown-uuid"
-            style="margin-right: 0px;"
           >
             <span
               class="m-input-style__text"
@@ -467,7 +463,7 @@ exports[`Storyshots components|m-dropdown/disabled No selection, no label 1`] = 
   >
     <div
       class="m-input-style m--is-disabled m--is-tag-default"
-      style="width: 100%; margin-top: 10px;"
+      style="width: 100%;"
     >
       <div
         class="m-input-style__main"
@@ -584,7 +580,7 @@ exports[`Storyshots components|m-dropdown/disabled No selection, no label, with 
   >
     <div
       class="m-input-style m--is-disabled m--is-tag-default"
-      style="width: 100%; margin-top: 10px;"
+      style="width: 100%;"
     >
       <div
         class="m-input-style__main"
@@ -700,7 +696,7 @@ exports[`Storyshots components|m-dropdown/disabled No selection, with label 1`] 
   >
     <div
       class="m-input-style m--is-disabled m--has-label m--is-tag-default"
-      style="width: 100%; margin-top: 10px;"
+      style="width: 100%;"
     >
       <div
         class="m-input-style__main"
@@ -711,7 +707,6 @@ exports[`Storyshots components|m-dropdown/disabled No selection, with label 1`] 
           <label
             class="m-input-style__label"
             for="mDropdown-uuid"
-            style="margin-right: 0px;"
           >
             <span
               class="m-input-style__text"
@@ -815,7 +810,7 @@ exports[`Storyshots components|m-dropdown/filterable No placeholder 1`] = `
 >
   <div
     class="m-input-style m--has-cursor-pointer m--has-label m--is-tag-default"
-    style="width: 100%; margin-top: 10px;"
+    style="width: 100%;"
   >
     <div
       class="m-input-style__main"
@@ -826,7 +821,6 @@ exports[`Storyshots components|m-dropdown/filterable No placeholder 1`] = `
         <label
           class="m-input-style__label"
           for="mDropdown-uuid"
-          style="margin-right: 0px;"
         >
           <span
             class="m-input-style__text"
@@ -937,7 +931,7 @@ exports[`Storyshots components|m-dropdown/filterable With placeholder 1`] = `
 >
   <div
     class="m-input-style m--has-cursor-pointer m--has-label m--is-tag-default"
-    style="width: 100%; margin-top: 10px;"
+    style="width: 100%;"
   >
     <div
       class="m-input-style__main"
@@ -948,7 +942,6 @@ exports[`Storyshots components|m-dropdown/filterable With placeholder 1`] = `
         <label
           class="m-input-style__label"
           for="mDropdown-uuid"
-          style="margin-right: 0px;"
         >
           <span
             class="m-input-style__text"
@@ -1054,7 +1047,7 @@ exports[`Storyshots components|m-dropdown/readonly Item selected, with label 1`]
   >
     <div
       class="m-input-style m--is-readonly m--is-label-up m--has-label m--has-value m--is-tag-default"
-      style="width: 100%; margin-top: 10px;"
+      style="width: 100%;"
     >
       <div
         class="m-input-style__main"
@@ -1065,7 +1058,6 @@ exports[`Storyshots components|m-dropdown/readonly Item selected, with label 1`]
           <label
             class="m-input-style__label"
             for="mDropdown-uuid"
-            style="margin-right: 0px;"
           >
             <span
               class="m-input-style__text"
@@ -1175,7 +1167,7 @@ exports[`Storyshots components|m-dropdown/readonly No selection, no label 1`] = 
   >
     <div
       class="m-input-style m--is-readonly m--is-tag-default"
-      style="width: 100%; margin-top: 10px;"
+      style="width: 100%;"
     >
       <div
         class="m-input-style__main"
@@ -1291,7 +1283,7 @@ exports[`Storyshots components|m-dropdown/readonly No selection, no label, with 
   >
     <div
       class="m-input-style m--is-readonly m--is-tag-default"
-      style="width: 100%; margin-top: 10px;"
+      style="width: 100%;"
     >
       <div
         class="m-input-style__main"
@@ -1407,7 +1399,7 @@ exports[`Storyshots components|m-dropdown/readonly No selection, with label 1`] 
   >
     <div
       class="m-input-style m--is-readonly m--is-label-up m--has-label m--is-tag-default"
-      style="width: 100%; margin-top: 10px;"
+      style="width: 100%;"
     >
       <div
         class="m-input-style__main"
@@ -1418,7 +1410,6 @@ exports[`Storyshots components|m-dropdown/readonly No selection, with label 1`] 
           <label
             class="m-input-style__label"
             for="mDropdown-uuid"
-            style="margin-right: 0px;"
           >
             <span
               class="m-input-style__text"
@@ -1528,7 +1519,7 @@ exports[`Storyshots components|m-dropdown/readonly No selection, with label, wit
   >
     <div
       class="m-input-style m--is-readonly m--is-label-up m--has-label m--is-tag-default"
-      style="width: 100%; margin-top: 10px;"
+      style="width: 100%;"
     >
       <div
         class="m-input-style__main"
@@ -1539,7 +1530,6 @@ exports[`Storyshots components|m-dropdown/readonly No selection, with label, wit
           <label
             class="m-input-style__label"
             for="mDropdown-uuid"
-            style="margin-right: 0px;"
           >
             <span
               class="m-input-style__text"

--- a/packages/modul-components/src/components/form/__snapshots__/form.stories.ts.snap
+++ b/packages/modul-components/src/components/form/__snapshots__/form.stories.ts.snap
@@ -14,7 +14,6 @@ exports[`Storyshots components|m-form default 1`] = `
   >
     <div
       class="m-input-style m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -145,7 +144,6 @@ exports[`Storyshots components|m-form reactive initial value 1`] = `
     >
       <div
         class="m-input-style m--has-value m--is-tag-default"
-        style="margin-top: 10px;"
       >
         <div
           class="m-input-style__main"
@@ -298,7 +296,6 @@ exports[`Storyshots components|m-form submit outside-form 1`] = `
     >
       <div
         class="m-input-style m--is-tag-default"
-        style="margin-top: 10px;"
       >
         <div
           class="m-input-style__main"
@@ -445,7 +442,7 @@ exports[`Storyshots components|m-form/all fields autocomplete 1`] = `
   >
     <div
       class="m-input-style m--has-cursor-pointer m--has-label m--is-tag-default"
-      style="width: 100%; margin-top: 10px;"
+      style="width: 100%;"
     >
       <div
         class="m-input-style__main"
@@ -456,7 +453,6 @@ exports[`Storyshots components|m-form/all fields autocomplete 1`] = `
           <label
             class="m-input-style__label"
             for="mDropdown-uuid"
-            style="margin-right: 0px;"
           >
             <span
               class="m-input-style__text"
@@ -730,7 +726,6 @@ exports[`Storyshots components|m-form/all fields datepicker 1`] = `
   >
     <div
       class="m-input-style m--has-label m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -741,7 +736,6 @@ exports[`Storyshots components|m-form/all fields datepicker 1`] = `
           <label
             class="m-input-style__label"
             for="mDatepicker-uuid"
-            style="margin-right: 0px;"
           >
             <span
               class="m-input-style__text"
@@ -985,7 +979,6 @@ exports[`Storyshots components|m-form/all fields decimalfield 1`] = `
   >
     <div
       class="m-input-style m--has-label m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -996,7 +989,6 @@ exports[`Storyshots components|m-form/all fields decimalfield 1`] = `
           <label
             class="m-input-style__label"
             for="mDecimalfield-uuid"
-            style="margin-right: 0px;"
           >
             <span
               class="m-input-style__text"
@@ -1133,7 +1125,7 @@ exports[`Storyshots components|m-form/all fields dropdown 1`] = `
   >
     <div
       class="m-input-style m--has-cursor-pointer m--has-label m--is-tag-default"
-      style="width: 100%; margin-top: 10px;"
+      style="width: 100%;"
     >
       <div
         class="m-input-style__main"
@@ -1144,7 +1136,6 @@ exports[`Storyshots components|m-form/all fields dropdown 1`] = `
           <label
             class="m-input-style__label"
             for="mDropdown-uuid"
-            style="margin-right: 0px;"
           >
             <span
               class="m-input-style__text"
@@ -1799,7 +1790,6 @@ exports[`Storyshots components|m-form/all fields textfield 1`] = `
   >
     <div
       class="m-input-style m--has-label m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -1810,7 +1800,6 @@ exports[`Storyshots components|m-form/all fields textfield 1`] = `
           <label
             class="m-input-style__label"
             for="mTextfield-uuid"
-            style="margin-right: 0px;"
           >
             <span
               class="m-input-style__text"
@@ -1948,7 +1937,6 @@ exports[`Storyshots components|m-form/all fields timepicker 1`] = `
   >
     <div
       class="m-input-style m--has-label m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -1959,7 +1947,6 @@ exports[`Storyshots components|m-form/all fields timepicker 1`] = `
           <label
             class="m-input-style__label"
             for="mTimepicker-uuid"
-            style="margin-right: 0px;"
           >
             <span
               class="m-input-style__text"
@@ -2114,7 +2101,6 @@ exports[`Storyshots components|m-form/built-in action-fallouts default 1`] = `
   >
     <div
       class="m-input-style m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -2244,7 +2230,6 @@ exports[`Storyshots components|m-form/built-in action-fallouts focus first field
   >
     <div
       class="m-input-style m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -2374,7 +2359,6 @@ exports[`Storyshots components|m-form/built-in action-fallouts message summary a
   >
     <div
       class="m-input-style m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -2504,7 +2488,6 @@ exports[`Storyshots components|m-form/built-in action-fallouts toast and clear t
   >
     <div
       class="m-input-style m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -3046,7 +3029,6 @@ exports[`Storyshots components|m-form/rules Email confirmation 1`] = `
           >
             <div
               class="m-input-style m--has-label m--is-tag-default"
-              style="margin-top: 10px;"
             >
               <div
                 class="m-input-style__main"
@@ -3057,7 +3039,6 @@ exports[`Storyshots components|m-form/rules Email confirmation 1`] = `
                   <label
                     class="m-input-style__label"
                     for="mTextfield-uuid"
-                    style="margin-right: 0px;"
                   >
                     <span
                       class="m-input-style__text"
@@ -3127,7 +3108,6 @@ exports[`Storyshots components|m-form/rules Email confirmation 1`] = `
           >
             <div
               class="m-input-style m--has-label m--is-tag-default"
-              style="margin-top: 10px;"
             >
               <div
                 class="m-input-style__main"
@@ -3138,7 +3118,6 @@ exports[`Storyshots components|m-form/rules Email confirmation 1`] = `
                   <label
                     class="m-input-style__label"
                     for="mTextfield-uuid"
-                    style="margin-right: 0px;"
                   >
                     <span
                       class="m-input-style__text"
@@ -3271,7 +3250,6 @@ exports[`Storyshots components|m-form/rules Format with fixed max characters (po
     >
       <div
         class="m-input-style m--has-label m--is-tag-default"
-        style="margin-top: 10px;"
       >
         <div
           class="m-input-style__main"
@@ -3282,7 +3260,6 @@ exports[`Storyshots components|m-form/rules Format with fixed max characters (po
             <label
               class="m-input-style__label"
               for="mTextfield-uuid"
-              style="margin-right: 0px;"
             >
               <span
                 class="m-input-style__text"
@@ -3412,7 +3389,6 @@ exports[`Storyshots components|m-form/rules Format without fixed max characters 
     >
       <div
         class="m-input-style m--has-label m--is-tag-default"
-        style="margin-top: 10px;"
       >
         <div
           class="m-input-style__main"
@@ -3423,7 +3399,6 @@ exports[`Storyshots components|m-form/rules Format without fixed max characters 
             <label
               class="m-input-style__label"
               for="mTextfield-uuid"
-              style="margin-right: 0px;"
             >
               <span
                 class="m-input-style__text"
@@ -3557,7 +3532,6 @@ exports[`Storyshots components|m-form/rules Live check username availability (as
     >
       <div
         class="m-input-style m--has-label m--is-tag-default"
-        style="margin-top: 10px;"
       >
         <div
           class="m-input-style__main"
@@ -3568,7 +3542,6 @@ exports[`Storyshots components|m-form/rules Live check username availability (as
             <label
               class="m-input-style__label"
               for="mTextfield-uuid"
-              style="margin-right: 0px;"
             >
               <span
                 class="m-input-style__text"
@@ -3702,7 +3675,6 @@ exports[`Storyshots components|m-form/rules More than one validations (course co
     >
       <div
         class="m-input-style m--has-label m--is-tag-default"
-        style="margin-top: 10px;"
       >
         <div
           class="m-input-style__main"
@@ -3713,7 +3685,6 @@ exports[`Storyshots components|m-form/rules More than one validations (course co
             <label
               class="m-input-style__label"
               for="mTextfield-uuid"
-              style="margin-right: 0px;"
             >
               <span
                 class="m-input-style__text"
@@ -4084,7 +4055,6 @@ exports[`Storyshots components|m-form/rules required and 5 characters min 1`] = 
     >
       <div
         class="m-input-style m--has-label m--is-tag-default"
-        style="margin-top: 10px;"
       >
         <div
           class="m-input-style__main"
@@ -4095,7 +4065,6 @@ exports[`Storyshots components|m-form/rules required and 5 characters min 1`] = 
             <label
               class="m-input-style__label"
               for="mTextfield-uuid"
-              style="margin-right: 0px;"
             >
               <span
                 class="m-input-style__text"
@@ -4225,7 +4194,6 @@ exports[`Storyshots components|m-form/rules required and 20 characters max 1`] =
     >
       <div
         class="m-input-style m--has-label m--is-tag-default"
-        style="margin-top: 10px;"
       >
         <div
           class="m-input-style__main"
@@ -4236,7 +4204,6 @@ exports[`Storyshots components|m-form/rules required and 20 characters max 1`] =
             <label
               class="m-input-style__label"
               for="mTextfield-uuid"
-              style="margin-right: 0px;"
             >
               <span
                 class="m-input-style__text"
@@ -4369,7 +4336,6 @@ exports[`Storyshots components|m-form/validation-type at-exit 1`] = `
   >
     <div
       class="m-input-style m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -4503,7 +4469,6 @@ exports[`Storyshots components|m-form/validation-type correction 1`] = `
   >
     <div
       class="m-input-style m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -4637,7 +4602,6 @@ exports[`Storyshots components|m-form/validation-type modification 1`] = `
   >
     <div
       class="m-input-style m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -4771,7 +4735,6 @@ exports[`Storyshots components|m-form/validation-type on-going 1`] = `
   >
     <div
       class="m-input-style m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -5050,7 +5013,6 @@ exports[`Storyshots components|m-form/validators date between 1`] = `
   >
     <div
       class="m-input-style m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -5214,7 +5176,6 @@ exports[`Storyshots components|m-form/validators date format 1`] = `
   >
     <div
       class="m-input-style m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -5378,7 +5339,6 @@ exports[`Storyshots components|m-form/validators email 1`] = `
   >
     <div
       class="m-input-style m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -5574,7 +5534,6 @@ exports[`Storyshots components|m-form/validators max-length 1`] = `
   >
     <div
       class="m-input-style m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -5770,7 +5729,6 @@ exports[`Storyshots components|m-form/validators min-length 1`] = `
   >
     <div
       class="m-input-style m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -5904,7 +5862,6 @@ exports[`Storyshots components|m-form/validators required 1`] = `
   >
     <div
       class="m-input-style m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"

--- a/packages/modul-components/src/components/input-group/__snapshots__/input-group.stories.ts.snap
+++ b/packages/modul-components/src/components/input-group/__snapshots__/input-group.stories.ts.snap
@@ -169,7 +169,6 @@ exports[`Storyshots components|m-input-group default 1`] = `
         >
           <div
             class="m-input-style m--has-label m--is-tag-default"
-            style="margin-top: 10px;"
           >
             <div
               class="m-input-style__main"
@@ -180,7 +179,6 @@ exports[`Storyshots components|m-input-group default 1`] = `
                 <label
                   class="m-input-style__label"
                   for="mTextfield-uuid"
-                  style="margin-right: 0px;"
                 >
                   <span
                     class="m-input-style__text"
@@ -250,7 +248,6 @@ exports[`Storyshots components|m-input-group default 1`] = `
         >
           <div
             class="m-input-style m--has-label m--is-tag-default"
-            style="margin-top: 10px;"
           >
             <div
               class="m-input-style__main"
@@ -261,7 +258,6 @@ exports[`Storyshots components|m-input-group default 1`] = `
                 <label
                   class="m-input-style__label"
                   for="mTextfield-uuid"
-                  style="margin-right: 0px;"
                 >
                   <span
                     class="m-input-style__text"

--- a/packages/modul-components/src/components/input-style/__snapshots__/input-style.spec.ts.snap
+++ b/packages/modul-components/src/components/input-style/__snapshots__/input-style.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MInputStyle should render correctly 1`] = `
-<div class="m-input-style m--is-tag-default">
+<div class="m-input-style m--is-tag-default" style="margin-top:;">
   <div class="m-input-style__main">
     <div class="m-input-style__body"><span class="m-input-style__label" style="z-index:-1;"><span class="m-input-style__text"></span></span>
       <div class="m-input-style__input">

--- a/packages/modul-components/src/components/input-style/__snapshots__/input-style.stories.ts.snap
+++ b/packages/modul-components/src/components/input-style/__snapshots__/input-style.stories.ts.snap
@@ -3,7 +3,6 @@
 exports[`Storyshots components|m-input-style cursorPointer 1`] = `
 <div
   class="m-input-style m--is-label-up m--has-cursor-pointer m--has-label m--has-value m--is-tag-default"
-  style="margin-top: 10px;"
 >
   <div
     class="m-input-style__main"
@@ -13,7 +12,6 @@ exports[`Storyshots components|m-input-style cursorPointer 1`] = `
     >
       <label
         class="m-input-style__label"
-        style="margin-right: 0px;"
       >
         <span
           class="m-input-style__text"
@@ -57,7 +55,6 @@ exports[`Storyshots components|m-input-style cursorPointer 1`] = `
 exports[`Storyshots components|m-input-style default 1`] = `
 <div
   class="m-input-style m--is-tag-default"
-  style="margin-top: 10px;"
 >
   <div
     class="m-input-style__main"
@@ -107,7 +104,6 @@ exports[`Storyshots components|m-input-style default 1`] = `
 exports[`Storyshots components|m-input-style disabled 1`] = `
 <div
   class="m-input-style m--is-label-up m--is-disabled m--has-label m--has-value m--is-tag-default"
-  style="margin-top: 10px;"
 >
   <div
     class="m-input-style__main"
@@ -117,7 +113,6 @@ exports[`Storyshots components|m-input-style disabled 1`] = `
     >
       <label
         class="m-input-style__label"
-        style="margin-right: 0px;"
       >
         <span
           class="m-input-style__text"
@@ -161,7 +156,6 @@ exports[`Storyshots components|m-input-style disabled 1`] = `
 exports[`Storyshots components|m-input-style empty 1`] = `
 <div
   class="m-input-style m--is-label-up m--has-label m--has-value m--is-tag-default"
-  style="margin-top: 10px;"
 >
   <div
     class="m-input-style__main"
@@ -171,7 +165,6 @@ exports[`Storyshots components|m-input-style empty 1`] = `
     >
       <label
         class="m-input-style__label"
-        style="margin-right: 0px;"
       >
         <span
           class="m-input-style__text"
@@ -216,7 +209,6 @@ exports[`Storyshots components|m-input-style error 1`] = `
 <div>
   <div
     class="m-input-style m--is-label-up m--has-error m--has-label m--has-value m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -226,7 +218,6 @@ exports[`Storyshots components|m-input-style error 1`] = `
       >
         <label
           class="m-input-style__label"
-          style="margin-right: 0px;"
         >
           <span
             class="m-input-style__text"
@@ -277,7 +268,6 @@ exports[`Storyshots components|m-input-style error 1`] = `
   </p>
   <div
     class="m-input-style m--is-label-up m--has-error m--has-label m--has-value m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -287,7 +277,6 @@ exports[`Storyshots components|m-input-style error 1`] = `
       >
         <label
           class="m-input-style__label"
-          style="margin-right: 0px;"
         >
           <span
             class="m-input-style__text"
@@ -332,7 +321,6 @@ exports[`Storyshots components|m-input-style error 1`] = `
 exports[`Storyshots components|m-input-style focus 1`] = `
 <div
   class="m-input-style m--is-focus m--is-label-up m--has-label m--has-value m--is-tag-default"
-  style="margin-top: 10px;"
 >
   <div
     class="m-input-style__main"
@@ -342,7 +330,6 @@ exports[`Storyshots components|m-input-style focus 1`] = `
     >
       <label
         class="m-input-style__label"
-        style="margin-right: 0px;"
       >
         <span
           class="m-input-style__text"
@@ -388,7 +375,6 @@ exports[`Storyshots components|m-input-style focus 1`] = `
 exports[`Storyshots components|m-input-style label 1`] = `
 <div
   class="m-input-style m--has-label m--is-tag-default"
-  style="margin-top: 10px;"
 >
   <div
     class="m-input-style__main"
@@ -398,7 +384,6 @@ exports[`Storyshots components|m-input-style label 1`] = `
     >
       <label
         class="m-input-style__label"
-        style="margin-right: 0px;"
       >
         <span
           class="m-input-style__text"
@@ -450,7 +435,6 @@ exports[`Storyshots components|m-input-style labelFor 1`] = `
 >
   <div
     class="m-input-style m--has-label m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -461,7 +445,6 @@ exports[`Storyshots components|m-input-style labelFor 1`] = `
         <label
           class="m-input-style__label"
           for="Label for"
-          style="margin-right: 0px;"
         >
           <span
             class="m-input-style__text"
@@ -522,7 +505,6 @@ exports[`Storyshots components|m-input-style labelFor 1`] = `
 exports[`Storyshots components|m-input-style readonly 1`] = `
 <div
   class="m-input-style m--is-readonly m--is-label-up m--has-label m--has-value m--is-tag-default"
-  style="margin-top: 10px;"
 >
   <div
     class="m-input-style__main"
@@ -532,7 +514,6 @@ exports[`Storyshots components|m-input-style readonly 1`] = `
     >
       <label
         class="m-input-style__label"
-        style="margin-right: 0px;"
       >
         <span
           class="m-input-style__text"
@@ -576,7 +557,6 @@ exports[`Storyshots components|m-input-style readonly 1`] = `
 exports[`Storyshots components|m-input-style requiredMarker 1`] = `
 <div
   class="m-input-style m--is-label-up m--has-label m--has-value m--is-tag-default"
-  style="margin-top: 10px;"
 >
   <div
     class="m-input-style__main"
@@ -586,7 +566,6 @@ exports[`Storyshots components|m-input-style requiredMarker 1`] = `
     >
       <label
         class="m-input-style__label"
-        style="margin-right: 0px;"
       >
         <span
           class="m-input-style__text"
@@ -636,7 +615,6 @@ exports[`Storyshots components|m-input-style rich text editor 1`] = `<!---->`;
 exports[`Storyshots components|m-input-style tagStyle 1`] = `
 <div
   class="m-input-style m--is-label-up m--has-label m--has-value m--is-tag-h1"
-  style="margin-top: 10px;"
 >
   <div
     class="m-input-style__main"
@@ -646,7 +624,6 @@ exports[`Storyshots components|m-input-style tagStyle 1`] = `
     >
       <label
         class="m-input-style__label"
-        style="margin-right: 0px;"
       >
         <span
           class="m-input-style__text"
@@ -690,7 +667,7 @@ exports[`Storyshots components|m-input-style tagStyle 1`] = `
 exports[`Storyshots components|m-input-style testAllProps 1`] = `
 <div
   class="m-input-style m--has-label m--is-tag-default"
-  style="width: 150px; margin-top: 10px;"
+  style="width: 150px;"
 >
   <div
     class="m-input-style__main"
@@ -700,7 +677,6 @@ exports[`Storyshots components|m-input-style testAllProps 1`] = `
     >
       <label
         class="m-input-style__label"
-        style="margin-right: 0px;"
       >
         <span
           class="m-input-style__text"
@@ -745,7 +721,6 @@ exports[`Storyshots components|m-input-style valid 1`] = `
 <div>
   <div
     class="m-input-style m--is-label-up m--is-valid m--has-label m--has-value m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -755,7 +730,6 @@ exports[`Storyshots components|m-input-style valid 1`] = `
       >
         <label
           class="m-input-style__label"
-          style="margin-right: 0px;"
         >
           <span
             class="m-input-style__text"
@@ -806,7 +780,6 @@ exports[`Storyshots components|m-input-style valid 1`] = `
   </p>
   <div
     class="m-input-style m--is-label-up m--has-error m--has-label m--has-value m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -816,7 +789,6 @@ exports[`Storyshots components|m-input-style valid 1`] = `
       >
         <label
           class="m-input-style__label"
-          style="margin-right: 0px;"
         >
           <span
             class="m-input-style__text"
@@ -861,7 +833,6 @@ exports[`Storyshots components|m-input-style valid 1`] = `
 exports[`Storyshots components|m-input-style waiting 1`] = `
 <div
   class="m-input-style m--is-label-up m--is-waiting m--has-label m--has-value m--is-tag-default"
-  style="margin-top: 10px;"
 >
   <div
     class="m-input-style__main"
@@ -871,7 +842,6 @@ exports[`Storyshots components|m-input-style waiting 1`] = `
     >
       <label
         class="m-input-style__label"
-        style="margin-right: 0px;"
       >
         <span
           class="m-input-style__text"
@@ -921,7 +891,7 @@ exports[`Storyshots components|m-input-style waiting 1`] = `
 exports[`Storyshots components|m-input-style width 1`] = `
 <div
   class="m-input-style m--is-focus m--is-label-up m--has-label m--has-value m--is-tag-default"
-  style="width: 150px; margin-top: 10px;"
+  style="width: 150px;"
 >
   <div
     class="m-input-style__main"
@@ -931,7 +901,6 @@ exports[`Storyshots components|m-input-style width 1`] = `
     >
       <label
         class="m-input-style__label"
-        style="margin-right: 0px;"
       >
         <span
           class="m-input-style__text"

--- a/packages/modul-components/src/components/input-style/input-style.scss
+++ b/packages/modul-components/src/components/input-style/input-style.scss
@@ -21,11 +21,12 @@ $m-input-style-border-radius: 3px;
     position: relative;
     display: inline-flex;
     outline: none;
+    transition: margin-top $m-transition-duration ease;
 
     &__main {
         border: 1px solid $m-color--grey-light;
         border-radius: $m-input-style-border-radius;
-        transition: border-color $m-transition-duration--l ease-in-out, margin-top $m-transition-duration ease;
+        transition: border-color $m-transition-duration--l ease-in-out;
         display: inline-flex;
         width: 100%;
     }
@@ -36,7 +37,6 @@ $m-input-style-border-radius: 3px;
         flex-direction: column;
         width: 100%;
         padding: $m-input-style--padding;
-        transition: border-color $m-transition-duration--l ease-in-out, margin-top $m-transition-duration ease;
     }
 
     &__append {

--- a/packages/modul-components/src/components/input-style/input-style.ts
+++ b/packages/modul-components/src/components/input-style/input-style.ts
@@ -8,8 +8,6 @@ import I18nPlugin from '../i18n/i18n';
 import SpinnerPlugin from '../spinner/spinner';
 import WithRender from './input-style.html?style=./input-style.scss';
 
-export const CSS_LABEL_DEFAULT_MARGIN: number = 10;
-
 @WithRender
 @Component({
     mixins: [InputState]
@@ -44,8 +42,8 @@ export class MInputStyle extends ModulVue {
         suffix: HTMLElement
     };
 
-    public labelOffset: string | undefined = CSS_LABEL_DEFAULT_MARGIN + 'px';
-    public suffixOffset: string | undefined = '0px';
+    public labelOffset: string = '';
+    public suffixOffset: string = '';
     public animReady: boolean = false;
 
     protected created(): void {
@@ -93,20 +91,18 @@ export class MInputStyle extends ModulVue {
     @Watch('isLabelUp')
     private computeLabelOffset(): void {
         if (this.label) {
-            let labelOffset: number = this.$refs.label.clientHeight / 2;
-            this.labelOffset = this.isLabelUp && labelOffset > CSS_LABEL_DEFAULT_MARGIN ? `${labelOffset}px` : `${CSS_LABEL_DEFAULT_MARGIN}px`;
-        } else {
-            this.labelOffset = undefined;
+            let labelHeight: number = this.$refs.label.clientHeight
+            let labelOffset: number = Math.ceil(labelHeight * 0.5);
+            let labelComputedStyle: CSSStyleDeclaration = window.getComputedStyle(this.$refs.label);
+            let labelfontSize: number = parseFloat(labelComputedStyle.getPropertyValue('font-size'));
+            let lines: number = Math.floor(labelHeight / labelfontSize);
+            this.labelOffset = this.isLabelUp && lines > 1 ? `${labelOffset}px` : '';
         }
     }
 
     public async computeSuffixOffset(): Promise<void> {
         await this.$nextTick();
-        if (this.label && this.$refs.suffix) {
-            this.suffixOffset = this.$refs.suffix.clientWidth + 'px';
-        } else {
-            this.suffixOffset = undefined;
-        }
+        this.suffixOffset = this.label ? this.$refs.suffix.clientWidth + 'px' : '';
     }
 
     public get isLabelUp(): boolean {

--- a/packages/modul-components/src/components/input-style/input-style.ts
+++ b/packages/modul-components/src/components/input-style/input-style.ts
@@ -91,7 +91,7 @@ export class MInputStyle extends ModulVue {
     @Watch('isLabelUp')
     private computeLabelOffset(): void {
         if (this.label) {
-            let labelHeight: number = this.$refs.label.clientHeight
+            let labelHeight: number = this.$refs.label.clientHeight;
             let labelOffset: number = Math.ceil(labelHeight * 0.5);
             let labelComputedStyle: CSSStyleDeclaration = window.getComputedStyle(this.$refs.label);
             let labelfontSize: number = parseFloat(labelComputedStyle.getPropertyValue('font-size'));

--- a/packages/modul-components/src/components/integerfield/__snapshots__/integerfield.spec.ts.snap
+++ b/packages/modul-components/src/components/integerfield/__snapshots__/integerfield.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`MTextfield should render correctly 1`] = `
 <div class="m-integerfield" style="width:100%;max-width:288px;">
-  <div class="m-input-style m--is-tag-default" style="margin-top:10px;">
+  <div class="m-input-style m--is-tag-default" style="margin-top:;">
     <div class="m-input-style__main">
       <div class="m-input-style__body"><span class="m-input-style__label" style="z-index:-1;"><span class="m-input-style__text"></span></span>
         <div class="m-input-style__input">

--- a/packages/modul-components/src/components/moneyfield/__snapshots__/moneyfield.spec.ts.snap
+++ b/packages/modul-components/src/components/moneyfield/__snapshots__/moneyfield.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`MTextfield should render correctly 1`] = `
 <div class="m-moneyfield" style="width:100%;max-width:136px;">
   <div class="m-decimalfield" style="width:100%;max-width:136px;">
-    <div class="m-input-style m--is-tag-default" style="margin-top:10px;">
+    <div class="m-input-style m--is-tag-default" style="margin-top:;">
       <div class="m-input-style__main">
         <div class="m-input-style__body"><span class="m-input-style__label" style="z-index:-1;"><span class="m-input-style__text"></span></span>
           <div class="m-input-style__input">

--- a/packages/modul-components/src/components/moneyfield/__snapshots__/moneyfield.stories.ts.snap
+++ b/packages/modul-components/src/components/moneyfield/__snapshots__/moneyfield.stories.ts.snap
@@ -13,7 +13,6 @@ exports[`Storyshots components|m-moneyfield Basic 1`] = `
       >
         <div
           class="m-input-style m--is-tag-default"
-          style="margin-top: 10px;"
         >
           <div
             class="m-input-style__main"
@@ -99,7 +98,6 @@ exports[`Storyshots components|m-moneyfield Basic 1`] = `
       >
         <div
           class="m-input-style m--has-label m--is-tag-default"
-          style="margin-top: 10px;"
         >
           <div
             class="m-input-style__main"
@@ -110,7 +108,6 @@ exports[`Storyshots components|m-moneyfield Basic 1`] = `
               <label
                 class="m-input-style__label"
                 for="mDecimalfield-uuid"
-                style="margin-right: 0px;"
               >
                 <span
                   class="m-input-style__text"
@@ -182,7 +179,6 @@ exports[`Storyshots components|m-moneyfield Basic 1`] = `
       >
         <div
           class="m-input-style m--has-label m--is-tag-default"
-          style="margin-top: 10px;"
         >
           <div
             class="m-input-style__main"
@@ -193,7 +189,6 @@ exports[`Storyshots components|m-moneyfield Basic 1`] = `
               <label
                 class="m-input-style__label"
                 for="mDecimalfield-uuid"
-                style="margin-right: 0px;"
               >
                 <span
                   class="m-input-style__text"
@@ -269,7 +264,6 @@ exports[`Storyshots components|m-moneyfield Basic 1`] = `
       >
         <div
           class="m-input-style m--is-valid m--is-tag-default"
-          style="margin-top: 10px;"
         >
           <div
             class="m-input-style__main"
@@ -378,7 +372,6 @@ exports[`Storyshots components|m-moneyfield Basic 1`] = `
       >
         <div
           class="m-input-style m--is-tag-default"
-          style="margin-top: 10px;"
         >
           <div
             class="m-input-style__main"
@@ -468,7 +461,6 @@ exports[`Storyshots components|m-moneyfield Basic 1`] = `
       >
         <div
           class="m-input-style m--has-error m--is-tag-default"
-          style="margin-top: 10px;"
         >
           <div
             class="m-input-style__main"
@@ -579,7 +571,6 @@ exports[`Storyshots components|m-moneyfield Custom precision 1`] = `
   >
     <div
       class="m-input-style m--has-value m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -665,7 +656,6 @@ exports[`Storyshots components|m-moneyfield Default precision 1`] = `
   >
     <div
       class="m-input-style m--has-value m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -751,7 +741,6 @@ exports[`Storyshots components|m-moneyfield Localization 1`] = `
   >
     <div
       class="m-input-style m--has-value m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -839,7 +828,6 @@ exports[`Storyshots components|m-moneyfield States 1`] = `
       >
         <div
           class="m-input-style m--is-disabled m--is-tag-default"
-          style="margin-top: 10px;"
         >
           <div
             class="m-input-style__main"
@@ -927,7 +915,6 @@ exports[`Storyshots components|m-moneyfield States 1`] = `
       >
         <div
           class="m-input-style m--is-readonly m--is-tag-default"
-          style="margin-top: 10px;"
         >
           <div
             class="m-input-style__main"
@@ -1015,7 +1002,6 @@ exports[`Storyshots components|m-moneyfield States 1`] = `
       >
         <div
           class="m-input-style m--is-waiting m--has-label m--is-tag-default"
-          style="margin-top: 10px;"
         >
           <div
             class="m-input-style__main"
@@ -1026,7 +1012,6 @@ exports[`Storyshots components|m-moneyfield States 1`] = `
               <label
                 class="m-input-style__label"
                 for="mDecimalfield-uuid"
-                style="margin-right: 0px;"
               >
                 <span
                   class="m-input-style__text"
@@ -1108,7 +1093,6 @@ exports[`Storyshots components|m-moneyfield With initial value (0) 1`] = `
   >
     <div
       class="m-input-style m--has-value m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -1194,7 +1178,6 @@ exports[`Storyshots components|m-moneyfield With initial value 1`] = `
   >
     <div
       class="m-input-style m--has-value m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"

--- a/packages/modul-components/src/components/periodpicker/__snapshots__/periodpicker.stories.ts.snap
+++ b/packages/modul-components/src/components/periodpicker/__snapshots__/periodpicker.stories.ts.snap
@@ -18,7 +18,6 @@ exports[`Storyshots components|m-periodpicker default 1`] = `
         >
           <div
             class="m-input-style m--has-label m--is-tag-default"
-            style="margin-top: 10px;"
           >
             <div
               class="m-input-style__main"
@@ -29,7 +28,6 @@ exports[`Storyshots components|m-periodpicker default 1`] = `
                 <label
                   class="m-input-style__label"
                   for="mDatepicker-uuid"
-                  style="margin-right: 0px;"
                 >
                   <span
                     class="m-input-style__text"
@@ -134,7 +132,6 @@ exports[`Storyshots components|m-periodpicker default 1`] = `
         >
           <div
             class="m-input-style m--has-label m--is-tag-default"
-            style="margin-top: 10px;"
           >
             <div
               class="m-input-style__main"
@@ -145,7 +142,6 @@ exports[`Storyshots components|m-periodpicker default 1`] = `
                 <label
                   class="m-input-style__label"
                   for="mDatepicker-uuid"
-                  style="margin-right: 0px;"
                 >
                   <span
                     class="m-input-style__text"

--- a/packages/modul-components/src/components/phonefield/__snapshots__/phonefield.stories.ts.snap
+++ b/packages/modul-components/src/components/phonefield/__snapshots__/phonefield.stories.ts.snap
@@ -15,7 +15,6 @@ exports[`Storyshots components|m-phonefield default 1`] = `
       >
         <div
           class="m-input-style m--is-label-up m--has-cursor-pointer m--has-label m--has-value m--is-tag-default"
-          style="margin-top: 10px;"
         >
           <div
             class="m-input-style__main"
@@ -26,7 +25,6 @@ exports[`Storyshots components|m-phonefield default 1`] = `
               <label
                 class="m-input-style__label"
                 for="m-select-uuid"
-                style="margin-right: 0px;"
               >
                 <span
                   class="m-input-style__text"
@@ -123,7 +121,6 @@ exports[`Storyshots components|m-phonefield default 1`] = `
       <div>
         <div
           class="m-input-style m-phonefield__number m--is-label-up m--has-label m--has-value m--is-tag-default"
-          style="margin-top: 10px;"
         >
           <div
             class="m-input-style__main"
@@ -134,7 +131,6 @@ exports[`Storyshots components|m-phonefield default 1`] = `
               <label
                 class="m-input-style__label"
                 for="mIntegerfield-uuid"
-                style="margin-right: 0px;"
               >
                 <span
                   class="m-input-style__text"
@@ -221,7 +217,6 @@ exports[`Storyshots components|m-phonefield detect country 1`] = `
     >
       <div
         class="m-input-style m--has-cursor-pointer m--has-value m--is-tag-default"
-        style="margin-top: 10px;"
       >
         <div
           class="m-input-style__main"
@@ -324,7 +319,6 @@ exports[`Storyshots components|m-phonefield detect country 1`] = `
         >
           <div
             class="m-input-style m--is-label-up m--has-cursor-pointer m--has-label m--is-tag-default"
-            style="margin-top: 10px;"
           >
             <div
               class="m-input-style__main"
@@ -335,7 +329,6 @@ exports[`Storyshots components|m-phonefield detect country 1`] = `
                 <label
                   class="m-input-style__label"
                   for="m-select-uuid"
-                  style="margin-right: 0px;"
                 >
                   <span
                     class="m-input-style__text"
@@ -432,7 +425,6 @@ exports[`Storyshots components|m-phonefield detect country 1`] = `
         <div>
           <div
             class="m-input-style m-phonefield__number m--is-label-up m--has-label m--has-value m--is-tag-default"
-            style="margin-top: 10px;"
           >
             <div
               class="m-input-style__main"
@@ -443,7 +435,6 @@ exports[`Storyshots components|m-phonefield detect country 1`] = `
                 <label
                   class="m-input-style__label"
                   for="mIntegerfield-uuid"
-                  style="margin-right: 0px;"
                 >
                   <span
                     class="m-input-style__text"
@@ -533,7 +524,6 @@ exports[`Storyshots components|m-phonefield disabled 1`] = `
     >
       <div
         class="m-input-style m--is-label-up m--is-disabled m--has-cursor-pointer m--has-label m--has-value m--is-tag-default"
-        style="margin-top: 10px;"
       >
         <div
           class="m-input-style__main"
@@ -544,7 +534,6 @@ exports[`Storyshots components|m-phonefield disabled 1`] = `
             <label
               class="m-input-style__label"
               for="m-select-uuid"
-              style="margin-right: 0px;"
             >
               <span
                 class="m-input-style__text"
@@ -626,7 +615,6 @@ exports[`Storyshots components|m-phonefield disabled 1`] = `
     <div>
       <div
         class="m-input-style m-phonefield__number m--is-label-up m--is-disabled m--has-label m--has-value m--is-tag-default"
-        style="margin-top: 10px;"
       >
         <div
           class="m-input-style__main"
@@ -637,7 +625,6 @@ exports[`Storyshots components|m-phonefield disabled 1`] = `
             <label
               class="m-input-style__label"
               for="mIntegerfield-uuid"
-              style="margin-right: 0px;"
             >
               <span
                 class="m-input-style__text"
@@ -718,7 +705,6 @@ exports[`Storyshots components|m-phonefield error 1`] = `
     >
       <div
         class="m-input-style m--is-label-up m--has-cursor-pointer m--has-error m--has-label m--has-value m--is-tag-default"
-        style="margin-top: 10px;"
       >
         <div
           class="m-input-style__main"
@@ -729,7 +715,6 @@ exports[`Storyshots components|m-phonefield error 1`] = `
             <label
               class="m-input-style__label"
               for="m-select-uuid"
-              style="margin-right: 0px;"
             >
               <span
                 class="m-input-style__text"
@@ -826,7 +811,6 @@ exports[`Storyshots components|m-phonefield error 1`] = `
     <div>
       <div
         class="m-input-style m-phonefield__number m--is-label-up m--has-error m--has-label m--has-value m--is-tag-default"
-        style="margin-top: 10px;"
       >
         <div
           class="m-input-style__main"
@@ -837,7 +821,6 @@ exports[`Storyshots components|m-phonefield error 1`] = `
             <label
               class="m-input-style__label"
               for="mIntegerfield-uuid"
-              style="margin-right: 0px;"
             >
               <span
                 class="m-input-style__text"
@@ -917,7 +900,6 @@ exports[`Storyshots components|m-phonefield error message 1`] = `
     >
       <div
         class="m-input-style m--is-label-up m--has-cursor-pointer m--has-error m--has-label m--has-value m--is-tag-default"
-        style="margin-top: 10px;"
       >
         <div
           class="m-input-style__main"
@@ -928,7 +910,6 @@ exports[`Storyshots components|m-phonefield error message 1`] = `
             <label
               class="m-input-style__label"
               for="m-select-uuid"
-              style="margin-right: 0px;"
             >
               <span
                 class="m-input-style__text"
@@ -1025,7 +1006,6 @@ exports[`Storyshots components|m-phonefield error message 1`] = `
     <div>
       <div
         class="m-input-style m-phonefield__number m--is-label-up m--has-error m--has-label m--has-value m--is-tag-default"
-        style="margin-top: 10px;"
       >
         <div
           class="m-input-style__main"
@@ -1036,7 +1016,6 @@ exports[`Storyshots components|m-phonefield error message 1`] = `
             <label
               class="m-input-style__label"
               for="mIntegerfield-uuid"
-              style="margin-right: 0px;"
             >
               <span
                 class="m-input-style__text"
@@ -1139,7 +1118,6 @@ exports[`Storyshots components|m-phonefield waiting 1`] = `
     >
       <div
         class="m-input-style m--is-label-up m--is-disabled m--has-cursor-pointer m--has-label m--has-value m--is-tag-default"
-        style="margin-top: 10px;"
       >
         <div
           class="m-input-style__main"
@@ -1150,7 +1128,6 @@ exports[`Storyshots components|m-phonefield waiting 1`] = `
             <label
               class="m-input-style__label"
               for="m-select-uuid"
-              style="margin-right: 0px;"
             >
               <span
                 class="m-input-style__text"
@@ -1232,7 +1209,6 @@ exports[`Storyshots components|m-phonefield waiting 1`] = `
     <div>
       <div
         class="m-input-style m-phonefield__number m--is-label-up m--is-waiting m--has-label m--has-value m--is-tag-default"
-        style="margin-top: 10px;"
       >
         <div
           class="m-input-style__main"
@@ -1243,7 +1219,6 @@ exports[`Storyshots components|m-phonefield waiting 1`] = `
             <label
               class="m-input-style__label"
               for="mIntegerfield-uuid"
-              style="margin-right: 0px;"
             >
               <span
                 class="m-input-style__text"

--- a/packages/modul-components/src/components/rich-text-editor/__snapshots__/rich-text-editor.spec.ts.snap
+++ b/packages/modul-components/src/components/rich-text-editor/__snapshots__/rich-text-editor.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`MRichTextEditor should render correctly 1`] = `
 <div class="m-rich-text" style="width:100%;max-width:288px;">
-  <div border-top="true" class="m-input-style m--is-tag-default" style="margin-top:10px;">
+  <div border-top="true" class="m-input-style m--is-tag-default" style="margin-top:;">
     <div class="m-input-style__main">
       <div class="m-input-style__body"><span class="m-input-style__label" style="z-index:-1;"><span class="m-input-style__text"></span></span>
         <div class="m-input-style__input">

--- a/packages/modul-components/src/components/searchfield/__snapshots__/searchfield.stories.ts.snap
+++ b/packages/modul-components/src/components/searchfield/__snapshots__/searchfield.stories.ts.snap
@@ -9,7 +9,6 @@ exports[`Storyshots components|m-searchfield default 1`] = `
     >
       <div
         class="m-input-style m--is-tag-default"
-        style="margin-top: 10px;"
         word-wrap="true"
       >
         <div
@@ -108,7 +107,6 @@ exports[`Storyshots components|m-searchfield error state 1`] = `
     >
       <div
         class="m-input-style m--is-label-up m--has-error m--has-label m--has-value m--is-tag-default"
-        style="margin-top: 10px;"
         word-wrap="true"
       >
         <div
@@ -120,7 +118,6 @@ exports[`Storyshots components|m-searchfield error state 1`] = `
             <label
               class="m-input-style__label"
               for="mSearchfield-uuid"
-              style="margin-right: 0px;"
             >
               <span
                 class="m-input-style__text"
@@ -257,7 +254,6 @@ exports[`Storyshots components|m-searchfield placeholder 1`] = `
     >
       <div
         class="m-input-style m--is-tag-default"
-        style="margin-top: 10px;"
         word-wrap="true"
       >
         <div
@@ -357,7 +353,6 @@ exports[`Storyshots components|m-searchfield valid state 1`] = `
     >
       <div
         class="m-input-style m--is-label-up m--is-valid m--has-label m--has-value m--is-tag-default"
-        style="margin-top: 10px;"
         word-wrap="true"
       >
         <div
@@ -369,7 +364,6 @@ exports[`Storyshots components|m-searchfield valid state 1`] = `
             <label
               class="m-input-style__label"
               for="mSearchfield-uuid"
-              style="margin-right: 0px;"
             >
               <span
                 class="m-input-style__text"
@@ -506,7 +500,6 @@ exports[`Storyshots components|m-searchfield with label 1`] = `
     >
       <div
         class="m-input-style m--has-label m--is-tag-default"
-        style="margin-top: 10px;"
         word-wrap="true"
       >
         <div
@@ -518,7 +511,6 @@ exports[`Storyshots components|m-searchfield with label 1`] = `
             <label
               class="m-input-style__label"
               for="mSearchfield-uuid"
-              style="margin-right: 0px;"
             >
               <span
                 class="m-input-style__text"

--- a/packages/modul-components/src/components/select/__snapshots__/select.stories.ts.snap
+++ b/packages/modul-components/src/components/select/__snapshots__/select.stories.ts.snap
@@ -9,7 +9,6 @@ exports[`Storyshots components|m-select default 1`] = `
   >
     <div
       class="m-input-style m--has-cursor-pointer m--has-value m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"

--- a/packages/modul-components/src/components/textarea/__snapshots__/textarea.spec.ts.snap
+++ b/packages/modul-components/src/components/textarea/__snapshots__/textarea.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`MTextArea max-length should render correctly state when text length is lesser than max length 1`] = `
 <div class="m-textarea" style="width:100%;max-width:288px;">
-  <div class="m-input-style m--has-value m--is-tag-default" style="margin-top:10px;">
+  <div class="m-input-style m--has-value m--is-tag-default" style="margin-top:;">
     <div class="m-input-style__main">
       <div class="m-input-style__body"><span class="m-input-style__label" style="z-index:-1;"><span class="m-input-style__text"></span></span>
         <div class="m-input-style__input">
@@ -21,7 +21,7 @@ exports[`MTextArea max-length should render correctly state when text length is 
 
 exports[`MTextArea max-length should render invalid state when text length is greater than max length 1`] = `
 <div class="m-textarea" style="width:100%;max-width:288px;">
-  <div class="m-input-style m--has-value m--is-tag-default" style="margin-top:10px;">
+  <div class="m-input-style m--has-value m--is-tag-default" style="margin-top:;">
     <div class="m-input-style__main">
       <div class="m-input-style__body"><span class="m-input-style__label" style="z-index:-1;"><span class="m-input-style__text"></span></span>
         <div class="m-input-style__input">
@@ -40,7 +40,7 @@ exports[`MTextArea max-length should render invalid state when text length is gr
 
 exports[`MTextArea should render correctly 1`] = `
 <div class="m-textarea" style="width:100%;max-width:288px;">
-  <div class="m-input-style m--is-tag-default" style="margin-top:10px;">
+  <div class="m-input-style m--is-tag-default" style="margin-top:;">
     <div class="m-input-style__main">
       <div class="m-input-style__body"><span class="m-input-style__label" style="z-index:-1;"><span class="m-input-style__text"></span></span>
         <div class="m-input-style__input">

--- a/packages/modul-components/src/components/textfield/__snapshots__/textfield.stories.ts.snap
+++ b/packages/modul-components/src/components/textfield/__snapshots__/textfield.stories.ts.snap
@@ -8,7 +8,6 @@ exports[`Storyshots components|m-textfield default 1`] = `
   >
     <div
       class="m-input-style m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -89,7 +88,6 @@ exports[`Storyshots components|m-textfield disabled 1`] = `
 >
   <div
     class="m-input-style m--is-disabled m--has-value m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -168,7 +166,6 @@ exports[`Storyshots components|m-textfield error 1`] = `
 >
   <div
     class="m-input-style m--has-error m--has-value m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -246,7 +243,6 @@ exports[`Storyshots components|m-textfield error-message 1`] = `
 >
   <div
     class="m-input-style m--has-error m--has-value m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -347,7 +343,6 @@ exports[`Storyshots components|m-textfield focus 1`] = `
 >
   <div
     class="m-input-style m--has-label m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -358,7 +353,6 @@ exports[`Storyshots components|m-textfield focus 1`] = `
         <label
           class="m-input-style__label"
           for="mTextfield-uuid"
-          style="margin-right: 0px;"
         >
           <span
             class="m-input-style__text"
@@ -431,7 +425,6 @@ exports[`Storyshots components|m-textfield helper-message 1`] = `
 >
   <div
     class="m-input-style m--has-value m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -507,84 +500,164 @@ exports[`Storyshots components|m-textfield helper-message 1`] = `
 `;
 
 exports[`Storyshots components|m-textfield label 1`] = `
-<div
-  class="m-textfield m--has-label m--is-type-text"
-  style="width: 100%; max-width: 288px;"
->
+<div>
   <div
-    class="m-input-style m--has-label m--is-tag-default"
-    style="margin-top: 10px;"
+    class="m-textfield m--has-label m--is-type-text"
+    style="width: 100%; max-width: 288px;"
   >
     <div
-      class="m-input-style__main"
+      class="m-input-style m--has-label m--is-tag-default"
     >
       <div
-        class="m-input-style__body"
+        class="m-input-style__main"
       >
-        <label
-          class="m-input-style__label"
-          for="mTextfield-uuid"
-          style="margin-right: 0px;"
-        >
-          <span
-            class="m-input-style__text"
-          >
-            <span>
-              A Label
-            </span>
-             
-            <!---->
-          </span>
-        </label>
-         
         <div
-          class="m-input-style__input"
+          class="m-input-style__body"
         >
-          <!---->
+          <label
+            class="m-input-style__label"
+            for="mTextfield-uuid"
+          >
+            <span
+              class="m-input-style__text"
+            >
+              <span>
+                A short Label
+              </span>
+               
+              <!---->
+            </span>
+          </label>
            
           <div
-            class="m-input-style__content"
+            class="m-input-style__input"
           >
-            <input
-              class="m-textfield__input"
-              id="mTextfield-uuid"
-              maxlength="Infinity"
-              type="text"
-            />
+            <!---->
+             
+            <div
+              class="m-input-style__content"
+            >
+              <input
+                class="m-textfield__input"
+                id="mTextfield-uuid"
+                maxlength="Infinity"
+                type="text"
+              />
+                 
+              <!---->
                
-            <!---->
+              <!---->
+               
+              <!---->
+            </div>
              
-            <!---->
-             
-            <!---->
-          </div>
-           
-          <div
-            class="m-input-style__suffix"
-          >
-            <!---->
-             
-            <!---->
+            <div
+              class="m-input-style__suffix"
+            >
+              <!---->
+               
+              <!---->
+            </div>
           </div>
         </div>
+         
+        <!---->
+      </div>
+    </div>
+     
+    <div
+      class="m-textfield__validation"
+    >
+      <div
+        class="m-validation-message m-textfield__validation__message"
+      >
+        <!---->
+         
+        <!---->
       </div>
        
       <!---->
     </div>
   </div>
+  <br />
    
   <div
-    class="m-textfield__validation"
+    class="m-textfield m--has-label m--is-type-text"
+    style="width: 100%; max-width: 288px;"
   >
     <div
-      class="m-validation-message m-textfield__validation__message"
+      class="m-input-style m--has-label m--is-tag-default"
     >
-      <!---->
+      <div
+        class="m-input-style__main"
+      >
+        <div
+          class="m-input-style__body"
+        >
+          <label
+            class="m-input-style__label"
+            for="mTextfield-uuid"
+          >
+            <span
+              class="m-input-style__text"
+            >
+              <span>
+                A longer label. Lorem ipsum dolor sit amet consectetur adipisicing elit.
+              </span>
+               
+              <!---->
+            </span>
+          </label>
+           
+          <div
+            class="m-input-style__input"
+          >
+            <!---->
+             
+            <div
+              class="m-input-style__content"
+            >
+              <input
+                class="m-textfield__input"
+                id="mTextfield-uuid"
+                maxlength="Infinity"
+                type="text"
+              />
+                 
+              <!---->
+               
+              <!---->
+               
+              <!---->
+            </div>
+             
+            <div
+              class="m-input-style__suffix"
+            >
+              <!---->
+               
+              <!---->
+            </div>
+          </div>
+        </div>
+         
+        <!---->
+      </div>
+    </div>
+     
+    <div
+      class="m-textfield__validation"
+    >
+      <div
+        class="m-validation-message m-textfield__validation__message"
+      >
+        <!---->
+         
+        <!---->
+      </div>
        
       <!---->
     </div>
-     
-    <!---->
   </div>
 </div>
 `;
@@ -596,7 +669,6 @@ exports[`Storyshots components|m-textfield label-up 1`] = `
 >
   <div
     class="m-input-style m--is-label-up m--has-label m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -607,7 +679,6 @@ exports[`Storyshots components|m-textfield label-up 1`] = `
         <label
           class="m-input-style__label"
           for="mTextfield-uuid"
-          style="margin-right: 0px;"
         >
           <span
             class="m-input-style__text"
@@ -680,7 +751,6 @@ exports[`Storyshots components|m-textfield placeholder 1`] = `
 >
   <div
     class="m-input-style m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -759,7 +829,6 @@ exports[`Storyshots components|m-textfield readonly 1`] = `
 >
   <div
     class="m-input-style m--is-readonly m--has-value m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -838,7 +907,6 @@ exports[`Storyshots components|m-textfield required-marker 1`] = `
 >
   <div
     class="m-input-style m--has-label m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -849,7 +917,6 @@ exports[`Storyshots components|m-textfield required-marker 1`] = `
         <label
           class="m-input-style__label"
           for="mTextfield-uuid"
-          style="margin-right: 0px;"
         >
           <span
             class="m-input-style__text"
@@ -925,7 +992,6 @@ exports[`Storyshots components|m-textfield valid 1`] = `
 >
   <div
     class="m-input-style m--is-valid m--has-value m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -1003,7 +1069,6 @@ exports[`Storyshots components|m-textfield valid-message 1`] = `
 >
   <div
     class="m-input-style m--is-valid m--has-value m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -1104,7 +1169,6 @@ exports[`Storyshots components|m-textfield value 1`] = `
 >
   <div
     class="m-input-style m--has-value m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -1182,7 +1246,6 @@ exports[`Storyshots components|m-textfield waiting 1`] = `
 >
   <div
     class="m-input-style m--is-waiting m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -1267,7 +1330,6 @@ exports[`Storyshots components|m-textfield word-wrap 1`] = `
 >
   <div
     class="m-input-style m--is-waiting m--has-value m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -1354,7 +1416,6 @@ exports[`Storyshots components|m-textfield/Counter all props 1`] = `
   >
     <div
       class="m-input-style m--has-label m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -1365,7 +1426,6 @@ exports[`Storyshots components|m-textfield/Counter all props 1`] = `
           <label
             class="m-input-style__label"
             for="mTextfield-uuid"
-            style="margin-right: 0px;"
           >
             <span
               class="m-input-style__text"
@@ -1502,7 +1562,6 @@ exports[`Storyshots components|m-textfield/Counter character-count 1`] = `
   >
     <div
       class="m-input-style m--has-value m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -1625,7 +1684,6 @@ exports[`Storyshots components|m-textfield/Counter character-count-threshold="10
   >
     <div
       class="m-input-style m--has-value m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -1762,7 +1820,6 @@ exports[`Storyshots components|m-textfield/Counter length-overflow="true" 1`] = 
   >
     <div
       class="m-input-style m--has-value m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -1873,7 +1930,6 @@ exports[`Storyshots components|m-textfield/Counter max-length="20" 1`] = `
   >
     <div
       class="m-input-style m--has-value m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -1984,7 +2040,6 @@ exports[`Storyshots components|m-textfield/Counter max-length="200" and :word-wr
   >
     <div
       class="m-input-style m--has-value m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -2109,7 +2164,6 @@ exports[`Storyshots components|m-textfield/max-width all max-width presets 1`] =
 >
   <div
     class="m-input-style m--has-label m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -2120,7 +2174,6 @@ exports[`Storyshots components|m-textfield/max-width all max-width presets 1`] =
         <label
           class="m-input-style__label"
           for="mTextfield-uuid"
-          style="margin-right: 0px;"
         >
           <span
             class="m-input-style__text"
@@ -2192,7 +2245,6 @@ exports[`Storyshots components|m-textfield/max-width custom width 1`] = `
 >
   <div
     class="m-input-style m--has-label m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -2203,7 +2255,6 @@ exports[`Storyshots components|m-textfield/max-width custom width 1`] = `
         <label
           class="m-input-style__label"
           for="mTextfield-uuid"
-          style="margin-right: 0px;"
         >
           <span
             class="m-input-style__text"
@@ -2275,7 +2326,6 @@ exports[`Storyshots components|m-textfield/max-width large 1`] = `
 >
   <div
     class="m-input-style m--has-label m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -2286,7 +2336,6 @@ exports[`Storyshots components|m-textfield/max-width large 1`] = `
         <label
           class="m-input-style__label"
           for="mTextfield-uuid"
-          style="margin-right: 0px;"
         >
           <span
             class="m-input-style__text"
@@ -2358,7 +2407,6 @@ exports[`Storyshots components|m-textfield/max-width medium 1`] = `
 >
   <div
     class="m-input-style m--has-label m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -2369,7 +2417,6 @@ exports[`Storyshots components|m-textfield/max-width medium 1`] = `
         <label
           class="m-input-style__label"
           for="mTextfield-uuid"
-          style="margin-right: 0px;"
         >
           <span
             class="m-input-style__text"
@@ -2442,7 +2489,6 @@ exports[`Storyshots components|m-textfield/max-width pyramid 1`] = `
   >
     <div
       class="m-input-style m--has-label m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -2453,7 +2499,6 @@ exports[`Storyshots components|m-textfield/max-width pyramid 1`] = `
           <label
             class="m-input-style__label"
             for="mTextfield-uuid"
-            style="margin-right: 0px;"
           >
             <span
               class="m-input-style__text"
@@ -2523,7 +2568,6 @@ exports[`Storyshots components|m-textfield/max-width pyramid 1`] = `
   >
     <div
       class="m-input-style m--has-label m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -2534,7 +2578,6 @@ exports[`Storyshots components|m-textfield/max-width pyramid 1`] = `
           <label
             class="m-input-style__label"
             for="mTextfield-uuid"
-            style="margin-right: 0px;"
           >
             <span
               class="m-input-style__text"
@@ -2604,7 +2647,6 @@ exports[`Storyshots components|m-textfield/max-width pyramid 1`] = `
   >
     <div
       class="m-input-style m--has-label m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -2615,7 +2657,6 @@ exports[`Storyshots components|m-textfield/max-width pyramid 1`] = `
           <label
             class="m-input-style__label"
             for="mTextfield-uuid"
-            style="margin-right: 0px;"
           >
             <span
               class="m-input-style__text"
@@ -2685,7 +2726,6 @@ exports[`Storyshots components|m-textfield/max-width pyramid 1`] = `
   >
     <div
       class="m-input-style m--has-label m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -2696,7 +2736,6 @@ exports[`Storyshots components|m-textfield/max-width pyramid 1`] = `
           <label
             class="m-input-style__label"
             for="mTextfield-uuid"
-            style="margin-right: 0px;"
           >
             <span
               class="m-input-style__text"
@@ -2768,7 +2807,6 @@ exports[`Storyshots components|m-textfield/max-width pyramid 1`] = `
   >
     <div
       class="m-input-style m--has-label m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -2779,7 +2817,6 @@ exports[`Storyshots components|m-textfield/max-width pyramid 1`] = `
           <label
             class="m-input-style__label"
             for="mTextfield-uuid"
-            style="margin-right: 0px;"
           >
             <span
               class="m-input-style__text"
@@ -2849,7 +2886,6 @@ exports[`Storyshots components|m-textfield/max-width pyramid 1`] = `
   >
     <div
       class="m-input-style m--has-label m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -2860,7 +2896,6 @@ exports[`Storyshots components|m-textfield/max-width pyramid 1`] = `
           <label
             class="m-input-style__label"
             for="mTextfield-uuid"
-            style="margin-right: 0px;"
           >
             <span
               class="m-input-style__text"
@@ -2932,7 +2967,6 @@ exports[`Storyshots components|m-textfield/max-width pyramid 1`] = `
   >
     <div
       class="m-input-style m--has-label m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -2943,7 +2977,6 @@ exports[`Storyshots components|m-textfield/max-width pyramid 1`] = `
           <label
             class="m-input-style__label"
             for="mTextfield-uuid"
-            style="margin-right: 0px;"
           >
             <span
               class="m-input-style__text"
@@ -3013,7 +3046,6 @@ exports[`Storyshots components|m-textfield/max-width pyramid 1`] = `
   >
     <div
       class="m-input-style m--has-label m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -3024,7 +3056,6 @@ exports[`Storyshots components|m-textfield/max-width pyramid 1`] = `
           <label
             class="m-input-style__label"
             for="mTextfield-uuid"
-            style="margin-right: 0px;"
           >
             <span
               class="m-input-style__text"
@@ -3096,7 +3127,6 @@ exports[`Storyshots components|m-textfield/max-width pyramid 1`] = `
   >
     <div
       class="m-input-style m--has-label m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -3107,7 +3137,6 @@ exports[`Storyshots components|m-textfield/max-width pyramid 1`] = `
           <label
             class="m-input-style__label"
             for="mTextfield-uuid"
-            style="margin-right: 0px;"
           >
             <span
               class="m-input-style__text"
@@ -3179,7 +3208,6 @@ exports[`Storyshots components|m-textfield/max-width pyramid 1`] = `
   >
     <div
       class="m-input-style m--has-label m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -3190,13 +3218,12 @@ exports[`Storyshots components|m-textfield/max-width pyramid 1`] = `
           <label
             class="m-input-style__label"
             for="mTextfield-uuid"
-            style="margin-right: 0px;"
           >
             <span
               class="m-input-style__text"
             >
               <span>
-                large
+                Lorem ipsum dolor sit amet consectetur adipisicing elit. Adipisci quae tempore aut sit doloribus error maiores unde repellat asperiores! Voluptatum doloremque pariatur ex minima culpa nobis, ullam blanditiis officiis numquam.
               </span>
                
               <!---->
@@ -3263,7 +3290,6 @@ exports[`Storyshots components|m-textfield/max-width regular 1`] = `
 >
   <div
     class="m-input-style m--has-label m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -3274,7 +3300,6 @@ exports[`Storyshots components|m-textfield/max-width regular 1`] = `
         <label
           class="m-input-style__label"
           for="mTextfield-uuid"
-          style="margin-right: 0px;"
         >
           <span
             class="m-input-style__text"
@@ -3346,7 +3371,6 @@ exports[`Storyshots components|m-textfield/max-width small 1`] = `
 >
   <div
     class="m-input-style m--has-label m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -3357,7 +3381,6 @@ exports[`Storyshots components|m-textfield/max-width small 1`] = `
         <label
           class="m-input-style__label"
           for="mTextfield-uuid"
-          style="margin-right: 0px;"
         >
           <span
             class="m-input-style__text"
@@ -3429,7 +3452,6 @@ exports[`Storyshots components|m-textfield/max-width x-small 1`] = `
 >
   <div
     class="m-input-style m--has-label m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -3440,7 +3462,6 @@ exports[`Storyshots components|m-textfield/max-width x-small 1`] = `
         <label
           class="m-input-style__label"
           for="mTextfield-uuid"
-          style="margin-right: 0px;"
         >
           <span
             class="m-input-style__text"
@@ -3512,7 +3533,6 @@ exports[`Storyshots components|m-textfield/tag-style all tag styles 1`] = `
 >
   <div
     class="m-input-style m--is-label-up m--has-label m--has-value m--is-tag-h3"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -3523,7 +3543,6 @@ exports[`Storyshots components|m-textfield/tag-style all tag styles 1`] = `
         <label
           class="m-input-style__label"
           for="mTextfield-uuid"
-          style="margin-right: 0px;"
         >
           <span
             class="m-input-style__text"
@@ -3595,7 +3614,6 @@ exports[`Storyshots components|m-textfield/type all types 1`] = `
 >
   <div
     class="m-input-style m--has-label m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -3606,7 +3624,6 @@ exports[`Storyshots components|m-textfield/type all types 1`] = `
         <label
           class="m-input-style__label"
           for="mTextfield-uuid"
-          style="margin-right: 0px;"
         >
           <span
             class="m-input-style__text"
@@ -3679,7 +3696,6 @@ exports[`Storyshots components|m-textfield/type type="email" 1`] = `
 >
   <div
     class="m-input-style m--has-value m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -3757,7 +3773,6 @@ exports[`Storyshots components|m-textfield/type type="number" 1`] = `
 >
   <div
     class="m-input-style m--has-value m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -3835,7 +3850,6 @@ exports[`Storyshots components|m-textfield/type type="password" 1`] = `
 >
   <div
     class="m-input-style m--is-label-up m--has-label m--has-value m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -3846,7 +3860,6 @@ exports[`Storyshots components|m-textfield/type type="password" 1`] = `
         <label
           class="m-input-style__label"
           for="mTextfield-uuid"
-          style="margin-right: 0px;"
         >
           <span
             class="m-input-style__text"
@@ -3940,7 +3953,6 @@ exports[`Storyshots components|m-textfield/type type="tel" 1`] = `
 >
   <div
     class="m-input-style m--has-value m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -4018,7 +4030,6 @@ exports[`Storyshots components|m-textfield/type type="text" 1`] = `
 >
   <div
     class="m-input-style m--has-value m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -4096,7 +4107,6 @@ exports[`Storyshots components|m-textfield/type type="url" 1`] = `
 >
   <div
     class="m-input-style m--has-value m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"

--- a/packages/modul-components/src/components/textfield/textfield.stories.ts
+++ b/packages/modul-components/src/components/textfield/textfield.stories.ts
@@ -46,12 +46,15 @@ storiesOf(`${componentsHierarchyRootSeparator}${TEXTFIELD_NAME}`, module)
         template: '<m-textfield :placeholder="placeholder"></m-textfield>'
     }))
     .add('label', () => ({
-        props: {
-            label: {
-                default: text('Label', 'A Label')
-            }
-        },
-        template: '<m-textfield :label="label"></m-textfield>'
+        data: () => ({
+            shortLabel: 'A short Label',
+            longLabel: 'A longer label. Lorem ipsum dolor sit amet consectetur adipisicing elit.'
+        }),
+        template: `
+        <div>
+            <m-textfield :label="shortLabel"></m-textfield><br />
+            <m-textfield :label="longLabel"></m-textfield>
+        </div>`
     }))
     .add('value', () => ({
         props: {
@@ -248,7 +251,7 @@ storiesOf(`${componentsHierarchyRootSeparator}${TEXTFIELD_NAME}/max-width`, modu
             <br />
             <m-textfield label="medium" max-width="medium" value=""></m-textfield>
             <br />
-            <m-textfield label="large" max-width="large" value=""></m-textfield>
+            <m-textfield label="Lorem ipsum dolor sit amet consectetur adipisicing elit. Adipisci quae tempore aut sit doloribus error maiores unde repellat asperiores! Voluptatum doloremque pariatur ex minima culpa nobis, ullam blanditiis officiis numquam." max-width="large" value=""></m-textfield>
         </div>
         `
     }));

--- a/packages/modul-components/src/components/timepicker/__snapshots__/timepicker.stories.ts.snap
+++ b/packages/modul-components/src/components/timepicker/__snapshots__/timepicker.stories.ts.snap
@@ -7,7 +7,6 @@ exports[`Storyshots components|m-timepicker default 1`] = `
 >
   <div
     class="m-input-style m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -116,7 +115,6 @@ exports[`Storyshots components|m-timepicker label 1`] = `
 >
   <div
     class="m-input-style m--has-label m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -127,7 +125,6 @@ exports[`Storyshots components|m-timepicker label 1`] = `
         <label
           class="m-input-style__label"
           for="mTimepicker-uuid"
-          style="margin-right: 0px;"
         >
           <span
             class="m-input-style__text"
@@ -230,7 +227,6 @@ exports[`Storyshots components|m-timepicker label-up 1`] = `
 >
   <div
     class="m-input-style m--is-label-up m--has-label m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -241,7 +237,6 @@ exports[`Storyshots components|m-timepicker label-up 1`] = `
         <label
           class="m-input-style__label"
           for="mTimepicker-uuid"
-          style="margin-right: 0px;"
         >
           <span
             class="m-input-style__text"
@@ -344,7 +339,6 @@ exports[`Storyshots components|m-timepicker max widht 1`] = `
 >
   <div
     class="m-input-style m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -453,7 +447,6 @@ exports[`Storyshots components|m-timepicker min 8:45 / max 15:15 1`] = `
 >
   <div
     class="m-input-style m--has-value m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"
@@ -563,7 +556,6 @@ exports[`Storyshots components|m-timepicker reactivity 1`] = `
   >
     <div
       class="m-input-style m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -670,7 +662,6 @@ exports[`Storyshots components|m-timepicker reactivity 1`] = `
   >
     <div
       class="m-input-style m--is-tag-default"
-      style="margin-top: 10px;"
     >
       <div
         class="m-input-style__main"
@@ -780,7 +771,6 @@ exports[`Storyshots components|m-timepicker step 15m 1`] = `
 >
   <div
     class="m-input-style m--is-tag-default"
-    style="margin-top: 10px;"
   >
     <div
       class="m-input-style__main"


### PR DESCRIPTION
<!--
Veuillez consulter les directives de contribution / Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Content can be written in English or in French
-->

## Description
<!-- Décrivez brièvement les changements introduits par ce PR / Provide a small description of the changes introduced by this PR -->
Le input-style ajoute maintenant une marge automatique **seulement si son label se retrouve sur plus d'une ligne**. Ce comportement à pour but d'éviter que le dit label overlap le contenu précédent après son animation.

Précédemment, il y avait toujours une marge minimale de 10px d'appliquée ce qui complexifiait inutilement la coexistence des divers composants de formulaire d'un point de vue d'unité et de cohérence visuel.

## Types de changements
<!--- Indiquez ici quels types de modifications votre code introduit / Indicated here what types of changes does your code introduce -->
- [ ] Correction de bug (sans `breaking change`)
- [ ] Amélioration (ajout par example une nouvelle propriété, évènement, slot ou méthode à un composant existant sans `breaking change`)
- [ ] Nouvelle fonctionalité (nouveau composant, directive, filtre ou service)
- [x] Breaking change (modification à une fonctionnalités existante qui nécessite une migration *remplir la section release note*)
- [ ] Refactoring/ménage (sans `breaking change`)
- [ ] Documentation/storybook (changement à la documentation ou aux storybooks qui n'affecte aucun package)
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Comment cela peut-il être testé?
<!--- Décrivez comment vous avez testé vos modifications / Please describe how you tested your changes -->
- [ ] Test unitaire (un nouveau test unitaire à été fait)
- [x] Storybook
- [ ] Test manuel / Sandboxes
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Inclure cette section dans les release notes
<!-- Pour chaque breaking changes , inscrire la description du changement et les instructions pour la migration -->
Les champs de formulaire n'auront plus de marge par défaut de 10px.
Par conséquent, des régressions visuels peuvent subvenir s'il n'étaient pas espacés autrement. ( par leur projet )

## Liens vers les récits Jira
<!-- Si vous êtes un contributeur interne, ajouter les liens vers vos billets Jira. -->
https://jira.dti.ulaval.ca/browse/ENA2-7123
<!--  Merci d'avoir contribué! / Thanks for contributing! -->
