### PR TITLE
N'essaie plus de mettre le focus quand l'élément n'est pas là

### DIFF
--- a/packages/modul-components/src/mixins/portal/portal.ts
+++ b/packages/modul-components/src/mixins/portal/portal.ts
@@ -88,13 +88,15 @@ export class Portal extends ModulVue implements PortalMixin {
     public setFocusToPortal(): void {
         if (this.as<PortalMixinImpl>().handlesFocus()) {
             let el: HTMLElement = this.as<PortalMixinImpl>().getPortalElement();
-            let x: number = window.pageXOffset; // AEL-53
-            let y: number = window.pageYOffset; // AEL-53
-            el.setAttribute('tabindex', '0');
-            el.focus();
-            window.scrollTo(x, y); // AEL-53
-            el.blur();
-            el.removeAttribute('tabindex');
+            if (el) {
+                let x: number = window.pageXOffset; // AEL-53
+                let y: number = window.pageYOffset; // AEL-53
+                el.setAttribute('tabindex', '0');
+                el.focus();
+                window.scrollTo(x, y); // AEL-53
+                el.blur();
+                el.removeAttribute('tabindex');
+            }
         }
     }
 


### PR DESCRIPTION
<!--
Veuillez consulter les directives de contribution / Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Content can be written in English or in French
-->

## Description
<!-- Décrivez brièvement les changements introduits par ce PR / Provide a small description of the changes introduced by this PR -->
Lorsque le setFocusToPortal ne trouve pas le portal dans le Dom, on n'essaie pas d'y ajouter des attributs

## Types de changements
<!--- Indiquez ici quels types de modifications votre code introduit / Indicated here what types of changes does your code introduce -->
- [x] Correction de bug (sans `breaking change`)
- [x] Amélioration (ajout par example une nouvelle propriété, évènement, slot ou méthode à un composant existant sans `breaking change`)
- [ ] Nouvelle fonctionalité (nouveau composant, directive, filtre ou service)
- [ ] Breaking change (modification à une fonctionnalités existante qui nécessite une migration *remplir la section release note*)
- [ ] Refactoring/ménage (sans `breaking change`)
- [ ] Documentation/storybook (changement à la documentation ou aux storybooks qui n'affecte aucun package)
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Comment cela peut-il être testé?
<!--- Décrivez comment vous avez testé vos modifications / Please describe how you tested your changes -->
- [ ] Test unitaire (un nouveau test unitaire à été fait)
- [ ] Storybook
- [ ] Test manuel / Sandboxes
- [x] Autre
<!-- si vous avez sélectionner autre, préciser ici -->
Lancer un overlay en appelant une méthode async qui prend plus de temps à se terminer que la valeur de transitionDuration. Le focus se fait appeler avant la création de la fenêtre


<!--  Merci d'avoir contribué! / Thanks for contributing! -->
