### PR TITLE
Feature/modul 1201 reset formcontrol

### DIFF
--- a/packages/modul-components/src/utils/form/form-control.spec.ts
+++ b/packages/modul-components/src/utils/form/form-control.spec.ts
@@ -139,14 +139,11 @@ describe('FromControl', () => {
                 formControl.value = 'bar';
             });
             it('should have a different value than the initial value', () => {
-                // expect((formControl as any)._initialValue).toEqual('\"foo\"');
                 expect(formControl.value).toEqual('bar');
             });
             it('on reset, should reset to correct the correct initial value', () => {
-
                 formControl.reset();
 
-                // expect((formControl as any)._initialValue).toEqual('\"foo\"');
                 expect(formControl.value).toEqual('foo');
             });
         });
@@ -164,15 +161,14 @@ describe('FromControl', () => {
             beforeEach(() => {
                 array.push('Bob');
                 array.splice(0, 1);
+                formControl.value = array;
             });
             it('should have a different value than the initial value', () => {
-                expect((formControl as any)._initialValue).toEqual('\[\"Alice\"\]');
                 expect(formControl.value).toEqual(['Bob']);
             });
             it('on reset, should reset to correct the correct initial value', () => {
                 formControl.reset();
 
-                expect((formControl as any)._initialValue).toEqual('\[\"Alice\"\]');
                 expect(formControl.value).toEqual(['Alice']);
             });
         });
@@ -201,13 +197,11 @@ describe('FromControl', () => {
                 formControl.value = nouvelleClasse;
             });
             it('should have a different value than the initial value', () => {
-                // expect((formControl as any)._initialValue).toEqual('\[\"foo\"\]');
                 expect(formControl.value).toEqual(nouvelleClasse);
             });
             it('on reset, should reset to correct the correct initial value', () => {
                 formControl.reset();
 
-                // expect((formControl as any)._initialValue).toEqual('\[\"foo\"\]');
                 expect(formControl.value).toEqual(vieilleClasse);
             });
             it('should return the object of the same class', () => {
@@ -221,14 +215,12 @@ describe('FromControl', () => {
                 formControl.value.bar = 'Eve';
             });
             it('should have a different value than the initial value', () => {
-                // expect((formControl as any)._initialValue).toEqual('\[\"foo\"\]');
                 expect(formControl.value).toEqual(new MyClass('Alice', 'Eve'));
             });
             it('on reset, should reset to correct the correct initial value', () => {
                 formControl.reset();
 
-                // expect((formControl as any)._initialValue).toEqual('\[\"foo\"\]');
-                expect(formControl.value).toEqual(vieilleClasse);
+                expect(formControl.value).toEqual(new MyClass('Alice', 'Bob'));
             });
         });
     });

--- a/packages/modul-components/src/utils/form/form-control.spec.ts
+++ b/packages/modul-components/src/utils/form/form-control.spec.ts
@@ -127,21 +127,109 @@ describe('FromControl', () => {
         });
     });
 
-
-    describe('When value change, initialvalue must not', () => {
-        beforeAll(() => {
+    describe('Given value is a primitive', () => {
+        beforeEach(() => {
             formControl = new FormControl<string>([],
                 {
                     initialValue: 'foo'
                 });
-
-            formControl.value = ['bar'];
         });
+        describe('When value has changed', () => {
+            beforeEach(() => {
+                formControl.value = 'bar';
+            });
+            it('should have a different value than the initial value', () => {
+                // expect((formControl as any)._initialValue).toEqual('\"foo\"');
+                expect(formControl.value).toEqual('bar');
+            });
+            it('on reset, should reset to correct the correct initial value', () => {
 
+                formControl.reset();
 
-        it('should run validation and set flag', () => {
-            expect((formControl as any)._initialValue).toBe('\"foo\"');
-            expect(formControl.value).toMatchObject(['bar']);
+                // expect((formControl as any)._initialValue).toEqual('\"foo\"');
+                expect(formControl.value).toEqual('foo');
+            });
+        });
+    });
+    describe('Given value is an array', () => {
+        let array: string[];
+        beforeEach(() => {
+            array = ['Alice'];
+            formControl = new FormControl<string[]>([],
+                {
+                    initialValue: array
+                });
+        });
+        describe('When value has changed', () => {
+            beforeEach(() => {
+                array.push('Bob');
+                array.splice(0, 1);
+            });
+            it('should have a different value than the initial value', () => {
+                expect((formControl as any)._initialValue).toEqual('\[\"Alice\"\]');
+                expect(formControl.value).toEqual(['Bob']);
+            });
+            it('on reset, should reset to correct the correct initial value', () => {
+                formControl.reset();
+
+                expect((formControl as any)._initialValue).toEqual('\[\"Alice\"\]');
+                expect(formControl.value).toEqual(['Alice']);
+            });
+        });
+    });
+
+    describe('Given value is an object', () => {
+        class MyClass {
+            foo: string;
+            bar: string;
+
+            constructor(foo: string, bar: string) {
+                this.foo = foo;
+                this.bar = bar;
+            }
+        }
+        const vieilleClasse: MyClass = new MyClass('Alice', 'Bob');
+        const nouvelleClasse: MyClass = new MyClass('Charlie', 'David');
+        beforeEach(() => {
+            formControl = new FormControl<MyClass>([],
+                {
+                    initialValue: vieilleClasse
+                });
+        });
+        describe('When value has changed', () => {
+            beforeEach(() => {
+                formControl.value = nouvelleClasse;
+            });
+            it('should have a different value than the initial value', () => {
+                // expect((formControl as any)._initialValue).toEqual('\[\"foo\"\]');
+                expect(formControl.value).toEqual(nouvelleClasse);
+            });
+            it('on reset, should reset to correct the correct initial value', () => {
+                formControl.reset();
+
+                // expect((formControl as any)._initialValue).toEqual('\[\"foo\"\]');
+                expect(formControl.value).toEqual(vieilleClasse);
+            });
+            it('should return the object of the same class', () => {
+                formControl.reset();
+
+                expect(formControl.value instanceof MyClass).toBe(true);
+            });
+        });
+        describe('When a property on the value has changed', () => {
+            beforeEach(() => {
+                formControl.value.bar = 'Eve';
+            });
+            it('should have a different value than the initial value', () => {
+                // expect((formControl as any)._initialValue).toEqual('\[\"foo\"\]');
+                expect(formControl.value).toEqual(new MyClass('Alice', 'Eve'));
+            });
+            it('on reset, should reset to correct the correct initial value', () => {
+                formControl.reset();
+
+                // expect((formControl as any)._initialValue).toEqual('\[\"foo\"\]');
+                expect(formControl.value).toEqual(vieilleClasse);
+            });
         });
     });
 });

--- a/packages/modul-components/src/utils/form/form-control.ts
+++ b/packages/modul-components/src/utils/form/form-control.ts
@@ -24,18 +24,21 @@ export class FormControl<T> extends AbstractControl {
         }
     }
 
+    private clone(oldObject: T): T {
+        const newObject: T = { ...oldObject };
+        Object.setPrototypeOf(newObject, Object.getPrototypeOf(oldObject));
+        return newObject;
+    }
+
     public set initialValue(initialValue: T) {
         if (Array.isArray(initialValue)) {
-            this._initialValue = ([...initialValue] as unknown as T);
-            this._value = ([...initialValue] as unknown as T);
-            this._oldValue = ([...initialValue] as unknown as T);
+            this._initialValue = [...initialValue] as unknown as T;
+            this._value = [...initialValue] as unknown as T;
+            this._oldValue = [...initialValue] as unknown as T;
         } else if (initialValue instanceof Object) {
-            this._initialValue = { ...initialValue };
-            Object.setPrototypeOf(this._initialValue, Object.getPrototypeOf(initialValue));
-            this._value = { ...initialValue };
-            Object.setPrototypeOf(this._value, Object.getPrototypeOf(initialValue));
-            this._oldValue = { ...initialValue };
-            Object.setPrototypeOf(this._oldValue, Object.getPrototypeOf(initialValue));
+            this._initialValue = this.clone(initialValue);
+            this._value = this.clone(initialValue);
+            this._oldValue = this.clone(initialValue);
         } else {
             this._initialValue = initialValue;
             this._value = initialValue;

--- a/packages/modul-components/src/utils/form/form-control.ts
+++ b/packages/modul-components/src/utils/form/form-control.ts
@@ -5,7 +5,7 @@ import { ControlValidator } from './validators/control-validator';
 
 export class FormControl<T> extends AbstractControl {
     private _value?: T;
-    private _initialValue?: string; // String instead of T to avoid that _initialValue contains a reference to another object. It's value must not be mutated.
+    private _initialValue?: T;
     private _oldValue?: T;
 
     constructor(
@@ -16,13 +16,30 @@ export class FormControl<T> extends AbstractControl {
 
         if (options) {
             if (options.initialValue !== undefined) {
-                this._initialValue = JSON.stringify(options.initialValue);
-                this._value = options.initialValue;
-                this._oldValue = options.initialValue;
+                this.initialValue = options.initialValue;
             }
         } else {
             // ensure reactivity
             this._value = undefined;
+        }
+    }
+
+    public set initialValue(initialValue: T) {
+        if (Array.isArray(initialValue)) {
+            this._initialValue = ([...initialValue] as unknown as T);
+            this._value = ([...initialValue] as unknown as T);
+            this._oldValue = ([...initialValue] as unknown as T);
+        } else if (initialValue instanceof Object) {
+            this._initialValue = { ...initialValue };
+            Object.setPrototypeOf(this._initialValue, Object.getPrototypeOf(initialValue));
+            this._value = { ...initialValue };
+            Object.setPrototypeOf(this._value, Object.getPrototypeOf(initialValue));
+            this._oldValue = { ...initialValue };
+            Object.setPrototypeOf(this._oldValue, Object.getPrototypeOf(initialValue));
+        } else {
+            this._initialValue = initialValue;
+            this._value = initialValue;
+            this._oldValue = initialValue;
         }
     }
 
@@ -115,11 +132,10 @@ export class FormControl<T> extends AbstractControl {
         this._touched = false;
 
         if (typeof initialValue === 'undefined') {
-            this._value = this._initialValue ? JSON.parse(this._initialValue) : undefined;
-            this._oldValue = this._initialValue ? JSON.parse(this._initialValue) : undefined;
+            this._value = this._initialValue;
+            this._oldValue = this._initialValue;
         } else {
-            this._value = this._oldValue = initialValue;
-            this._initialValue = JSON.stringify(initialValue);
+            this.initialValue = initialValue;
         }
     }
 

--- a/src/storybook/src/modul-components/components/form/__snapshots__/form.stories.ts.snap
+++ b/src/storybook/src/modul-components/components/form/__snapshots__/form.stories.ts.snap
@@ -1798,7 +1798,7 @@ exports[`Storyshots modul-components|m-form/all fields multi-select 1`] = `
         tabindex="0"
       >
         <div
-          class="m-input-style m--has-cursor-pointer m--has-label m--is-tag-default"
+          class="m-input-style m--is-label-up m--has-cursor-pointer m--has-label m--has-value m--is-tag-default"
           style="margin-top: 10px;"
         >
           <div
@@ -1837,7 +1837,49 @@ exports[`Storyshots modul-components|m-form/all fields multi-select 1`] = `
                 >
                   <div
                     class="m-multi-select__chips"
-                  />
+                  >
+                    <div
+                      class="m-chip-delete m-multi-select__chip m--is-small"
+                    >
+                      <div
+                        class="m-chip-delete__body"
+                      >
+                        <span
+                          class="m-chip-delete__text"
+                          id="mChipDeleteText-fakeId"
+                        >
+                          <span
+                            class="m-chip-delete__hidden-text"
+                          >
+                            Supprimer : 
+                          </span>
+                           
+                                    Maria Rainer
+                                
+                        </span>
+                         
+                        <button
+                          aria-labelledby="mChipDeleteText-fakeId"
+                          class="m-chip-delete__button"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="m-icon m-chip-delete__icon"
+                            height="8px"
+                            width="8px"
+                          >
+                            <!---->
+                             
+                            <use
+                              aria-hidden="true"
+                              class=""
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
                     
                   <!---->
                    

--- a/src/storybook/src/modul-components/components/form/form.stories.ts
+++ b/src/storybook/src/modul-components/components/form/form.stories.ts
@@ -1887,7 +1887,7 @@ storiesOf(`${modulComponentsHierarchyRootSeparator}${FORM_NAME}/all fields`, mod
                     'multi-select': new FormControl<string[]>(
                         [
                             RequiredValidator({ controlLabel: 'multi-select' })
-                        ], { initialValue: [] }
+                        ], { initialValue: ['Maria Rainer'] }
                     )
                 }
             ),
@@ -1896,6 +1896,12 @@ storiesOf(`${modulComponentsHierarchyRootSeparator}${FORM_NAME}/all fields`, mod
         computed: {
             multiSelectField(): void {
                 return (this).$data.formGroup.getControl('multi-select');
+            }
+        },
+        methods: {
+            submit(): void {
+                let submittedValues: string[] = (this as any).multiSelectField.value;
+                (this as any).multiSelectField.reset(submittedValues);
             }
         },
         template: `
@@ -1913,7 +1919,7 @@ storiesOf(`${modulComponentsHierarchyRootSeparator}${FORM_NAME}/all fields`, mod
                             :options="options"
                             :required-marker="true"></m-multi-select>
             <div class="m-u--margin-top--l m-u--margin-bottom--l">
-                <m-button type="submit">Submit</m-button>
+                <m-button type="submit" @click="submit()">Submit</m-button>
                 <m-button type="reset" @reset([])
                           skin="secondary">Reset</m-button>
             </div>


### PR DESCRIPTION
<!--
Veuillez consulter les directives de contribution / Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Content can be written in English or in French
-->

## Description
Instancie un nouvel objet/array lors de l'initialisation d'un formfield.
Ajout de cas de tests.


## Types de changements
<!--- Indiquez ici quels types de modifications votre code introduit / Indicated here what types of changes does your code introduce -->
- [ ] Correction de bug (sans `breaking change`)
- [ ] Amélioration (ajout par example une nouvelle propriété, évènement, slot ou méthode à un composant existant sans `breaking change`)
- [ ] Nouvelle fonctionalité (nouveau composant, directive, filtre ou service)
- [x] Breaking change (modification à une fonctionnalités existante qui nécessite une migration *remplir la section release note*)
- [ ] Refactoring/ménage (sans `breaking change`)
- [ ] Documentation/storybook (changement à la documentation ou aux storybooks qui n'affecte aucun package)
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Comment cela peut-il être testé?
<!--- Décrivez comment vous avez testé vos modifications / Please describe how you tested your changes -->
- [x] Test unitaire (un nouveau test unitaire à été fait)
- [x] Storybook
- [ ] Test manuel / Sandboxes
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Inclure cette section dans les release notes
Dans le formfield, Value retourne la même class que celle utilisé lors de l'initialisation à partir de initialValue, incluant le prototype.

## Liens internes
https://jira.dti.ulaval.ca/browse/MODUL-1201

<!--  Merci d'avoir contribué! / Thanks for contributing! -->
