### PR TITLE
resolve rte focus problem

### DIFF
--- a/packages/modul-components/src/components/rich-text-editor/adapter/vue-froala.html
+++ b/packages/modul-components/src/components/rich-text-editor/adapter/vue-froala.html
@@ -1,5 +1,5 @@
 <div class="vue-froala"
-     @click.stop
+     @click="onClick"
      @mousedown.capture="isDirty = !disabled"
      @touchstart.capture="isDirty = !disabled"
      :style="{ 'min-height': minHeight }"

--- a/packages/modul-components/src/components/rich-text-editor/adapter/vue-froala.ts
+++ b/packages/modul-components/src/components/rich-text-editor/adapter/vue-froala.ts
@@ -494,6 +494,14 @@ const SCROLL_TO_OFFSET: number = -50;
         }
     }
 
+    private onClick(event: Event): void {
+        if (this.froalaEditor.popups) {
+            event.stopPropagation();
+        } else {
+            this.$emit('click');
+        }
+    }
+
     private hideToolbar(): void {
         if (this.editorIsAvailable()) {
             this.froalaEditor.toolbar.hide();

--- a/packages/modul-components/src/components/rich-text-editor/rich-text-editor.html
+++ b/packages/modul-components/src/components/rich-text-editor/rich-text-editor.html
@@ -6,7 +6,7 @@
     'm--is-focus' : isFocus,
     'm--has-label': hasLabel,
     'm--has-validation-message': hasValidationMessage  }"
-     @click="onClick"
+     @click.stop="onClick"
      :style="{ width: inputWidth, maxWidth: inputMaxWidth }">
     <m-input-style :disabled="isDisabled"
                    :waiting="isWaiting"


### PR DESCRIPTION

## Description
Le but est de résoudre le problème de focus entre l'éditeur rte et la fenêtre d'insertion de lien de froala. En effet, l'éditeur prend le focus lorsque l'on clique sur un champ de la fenêtre d'insertion de lien. Pour résoudre cela, l'évènement click n'est propagé que si aucune popup n'est ouverte.

## Types de changements
- [x] Correction de bug (sans `breaking change`)
- [ ] Amélioration (ajout par example une nouvelle propriété, évènement, slot ou méthode à un composant existant sans `breaking change`)
- [ ] Nouvelle fonctionalité (nouveau composant, directive, filtre ou service)
- [ ] Breaking change (modification à une fonctionnalités existante qui nécessite une migration *remplir la section release note*)
- [ ] Refactoring/ménage (sans `breaking change`)
- [ ] Documentation/storybook (changement à la documentation ou aux storybooks qui n'affecte aucun package)
- [ ] Autre

## Comment cela peut-il être testé?
<!--- Décrivez comment vous avez testé vos modifications / Please describe how you tested your changes -->
- [ ] Test unitaire (un nouveau test unitaire à été fait)
- [x] Storybook
- [ ] Test manuel / Sandboxes
- [ ] Autre

## Inclure cette section dans les release notes

## Liens internes

