### PR TITLE
MODUL-1204 - Use Promise instead of url on proxy google

### DIFF
--- a/packages/modul-components/src/components/address/address.ts
+++ b/packages/modul-components/src/components/address/address.ts
@@ -16,7 +16,7 @@ export interface AddressPluginOptions {
 }
 
 const AddressPlugin: PluginObject<any> = {
-    install(v, options: AddressPluginOptions | undefined = { loqateKey: '', googleKey: '', googleProxy: {} }): void {
+    install(v, options: AddressPluginOptions | undefined = { loqateKey: '', googleKey: '', googleProxy: {} as GoogleProxyLookupPluginOptions }): void {
         v.use(AddressLookupPlugin, { loqateKey: options.loqateKey, googleKey: options.googleKey, googleProxy: options.googleProxy } as AddressLookupPluginOptions);
         v.use(AutoCompletePlugin);
         v.use(PoweredByGooglePlugin);

--- a/packages/modul-components/src/utils/address-lookup/address-lookup-proxy-google-service.ts
+++ b/packages/modul-components/src/utils/address-lookup/address-lookup-proxy-google-service.ts
@@ -1,27 +1,25 @@
-import { AxiosResponse } from 'axios';
-import { HttpService } from '../http/http';
 import uuid from '../uuid/uuid';
 import { Address, AddressSummary } from './address';
 import { AddressLookupFindQuery, AddressLookupRetrieveQuery, AddressLookupService, AddressLookupServiceProvider } from './address-lookup';
 import { GoogleFindResponseBuilder, GoogleRetrieveResponseBuilder } from './address-lookup-google';
+import { AutocompletePredictionResponse, PlaceResultResponse } from './address-lookup-proxy-google';
 import { AddressLookupToAddressSummary, AddressRetrieveToAddress } from './address-lookup-response-mapper';
 
 export default class AddressLookupGoogleProxyService implements AddressLookupService {
     serviceProvider = AddressLookupServiceProvider.GoogleProxy;
     private sessionToken?: string;
-    private httpService: HttpService;
-    private findUrl: string;
-    private retrieveUrl: string;
 
     /**
-     * Use this service if you have your own proxy to google. Such a proxy is useful to keep your googleAPI key secret.
+     * Use this service if you have your own proxy to google. A proxy is useful to keep your googleAPI key secret.
      * @param findUrl https://developers.google.com/places/web-service/autocomplete
      * @param retrieveUrl https://developers.google.com/places/web-service/details
      */
-    constructor(findUrl: string, retrieveUrl: string) {
-        this.httpService = new HttpService();
-        this.findUrl = findUrl;
-        this.retrieveUrl = retrieveUrl;
+    constructor(
+        protected findPromise: (params: google.maps.places.AutocompletionRequest) => Promise<AutocompletePredictionResponse>,
+        protected retrievePromise: (params: google.maps.places.PlaceDetailsRequest) => Promise<PlaceResultResponse>,
+        protected findErrorCallback: (error: ErrorEvent) => void,
+        protected retrieveErrorCallback: (error: ErrorEvent) => void
+    ) {
     }
 
     async find(query: AddressLookupFindQuery): Promise<AddressSummary[]> {
@@ -30,11 +28,16 @@ export default class AddressLookupGoogleProxyService implements AddressLookupSer
             input: query.input,
             sessionToken: this.sessionToken
         };
-        const results: google.maps.places.AutocompletePrediction[] = await this.httpService.execute({
-            method: 'GET',
-            rawUrl: this.findUrl,
-            params
-        }).then((r: AxiosResponse<unknown>) => ((r.data as any).predictions as google.maps.places.AutocompletePrediction[]));
+
+        const results: google.maps.places.AutocompletePrediction[] = await this.findPromise({
+            input: params.input,
+            sessionToken: params.sessionToken!.toString()
+        })
+            .then((response: AutocompletePredictionResponse) => (response.predictions))
+            .catch((error: ErrorEvent) => {
+                this.findErrorCallback(error);
+                return [];
+            });
 
         return results
             .map((prediction: google.maps.places.AutocompletePrediction) => new GoogleFindResponseBuilder()
@@ -50,21 +53,30 @@ export default class AddressLookupGoogleProxyService implements AddressLookupSer
             sessionToken: this.sessionToken
         };
 
-        const results: google.maps.places.PlaceResult = await this.httpService.execute({
-            method: 'GET',
-            rawUrl: this.retrieveUrl,
-            params
-        }).then((r: AxiosResponse<unknown>) => (r.data as any) as google.maps.places.PlaceResult);
+        const results: google.maps.places.PlaceResult[] = await this.retrievePromise({
+            placeId: params.placeId,
+            sessionToken: params.sessionToken!.toString()
+        })
+            .then((response: PlaceResultResponse) => [response.result])
+            .catch((error: ErrorEvent) => {
+                this.retrieveErrorCallback(error);
+                return [];
+            });
 
         this.discardToken();
 
-        const address: Address = new GoogleRetrieveResponseBuilder()
-            .setRequest(params)
-            .setResult(results)
-            .build()
-            .mapTo(new AddressRetrieveToAddress());
+        let address: Address;
+        if (results.length > 0) {
+            address = new GoogleRetrieveResponseBuilder()
+                .setRequest(params)
+                .setResult(results[0])
+                .build()
+                .mapTo(new AddressRetrieveToAddress());
 
-        return [address];
+            return [address];
+        } else {
+            return [];
+        }
     }
 
     private ensureCreateToken(): void {

--- a/packages/modul-components/src/utils/address-lookup/address-lookup-proxy-google.ts
+++ b/packages/modul-components/src/utils/address-lookup/address-lookup-proxy-google.ts
@@ -1,0 +1,9 @@
+export type AutocompletePredictionResponse = {
+    status: string;
+    predictions: google.maps.places.AutocompletePrediction[];
+};
+
+export type PlaceResultResponse = {
+    result: google.maps.places.PlaceResult;
+    status: string;
+};

--- a/packages/modul-components/src/utils/address-lookup/address-lookup-response-mapper.ts
+++ b/packages/modul-components/src/utils/address-lookup/address-lookup-response-mapper.ts
@@ -5,7 +5,7 @@ import { LoqateFindResponse, LoqateRetrieveResponse } from './address-lookup-loq
 const KEY_ADDRESS_TYPE: string = 'address';
 
 enum GOOGLE_ADDRESS_COMPONENTS {
-    STREER_NUMBER = 'street_number',
+    STREET_NUMBER = 'street_number',
     ROUTE = 'route',
     LOCALITY = 'locality',
     POSTAL_CODE = 'postal_code',
@@ -116,7 +116,7 @@ export class AddressRetrieveToAddress implements RetrieveResponseMapper<Address>
         if (!response.request || !response.result) { return undefined!; }
 
         const componentsByType: { [key: string]: google.maps.GeocoderAddressComponent } = {
-            [GOOGLE_ADDRESS_COMPONENTS.STREER_NUMBER]: { long_name: '', short_name: '', types: [] },
+            [GOOGLE_ADDRESS_COMPONENTS.STREET_NUMBER]: { long_name: '', short_name: '', types: [] },
             [GOOGLE_ADDRESS_COMPONENTS.ROUTE]: { long_name: '', short_name: '', types: [] },
             [GOOGLE_ADDRESS_COMPONENTS.LOCALITY]: { long_name: '', short_name: '', types: [] },
             [GOOGLE_ADDRESS_COMPONENTS.POSTAL_CODE]: { long_name: '', short_name: '', types: [] },
@@ -130,7 +130,7 @@ export class AddressRetrieveToAddress implements RetrieveResponseMapper<Address>
         });
 
         return {
-            buildingNumber: componentsByType[GOOGLE_ADDRESS_COMPONENTS.STREER_NUMBER].long_name,
+            buildingNumber: componentsByType[GOOGLE_ADDRESS_COMPONENTS.STREET_NUMBER].long_name,
             street: componentsByType[GOOGLE_ADDRESS_COMPONENTS.ROUTE].long_name,
             city: componentsByType[GOOGLE_ADDRESS_COMPONENTS.LOCALITY].long_name,
             postalCode: componentsByType[GOOGLE_ADDRESS_COMPONENTS.POSTAL_CODE].long_name,

--- a/packages/modul-components/src/utils/address-lookup/address-lookup.plugin.ts
+++ b/packages/modul-components/src/utils/address-lookup/address-lookup.plugin.ts
@@ -3,6 +3,7 @@ import { PluginObject } from 'vue';
 import { AddressLookupService } from './address-lookup';
 import AddressLookupGoogleService from './address-lookup-google-service';
 import AddressLookupLoqateService from './address-lookup-loqate-service';
+import { AutocompletePredictionResponse, PlaceResultResponse } from './address-lookup-proxy-google';
 import AddressLookupGoogleProxyService from './address-lookup-proxy-google-service';
 
 declare module 'vue/types/vue' {
@@ -18,12 +19,14 @@ export interface AddressLookupPluginOptions {
 }
 
 export type GoogleProxyLookupPluginOptions = {
-    findUrl?: string,
-    retrieveUrl?: string
+    findPromise: (params: { input: string, sessionToken: string }) => Promise<AutocompletePredictionResponse>,
+    retrievePromise: (params: { placeId: string, sessionToken: string }) => Promise<PlaceResultResponse>
+    findErrorCallback: (error: ErrorEvent) => void;
+    retrieveErrorCallback: (error: ErrorEvent) => void;
 };
 
 const AddressLookupPlugin: PluginObject<any> = {
-    install(v, options: AddressLookupPluginOptions | undefined = { loqateKey: '', googleKey: '', googleProxy: {} }): void {
+    install(v, options: AddressLookupPluginOptions | undefined = { loqateKey: '', googleKey: '', googleProxy: {} as GoogleProxyLookupPluginOptions }): void {
         if (options.loqateKey && options.googleKey) {
             v.prototype.$log.error('The API key for Loqate Web Service OR Google Maps API must be provided');
         }
@@ -33,8 +36,8 @@ const AddressLookupPlugin: PluginObject<any> = {
             addressLookup = new AddressLookupGoogleService(axios, options.googleKey);
         } else if (options.loqateKey) {
             addressLookup = new AddressLookupLoqateService(axios, options.loqateKey);
-        } else if (options.googleProxy && options.googleProxy.findUrl && options.googleProxy.retrieveUrl) {
-            addressLookup = new AddressLookupGoogleProxyService(options.googleProxy.findUrl, options.googleProxy.retrieveUrl);
+        } else if (!(Object.keys(options.googleProxy).length === 0 && options.googleProxy.constructor === Object)) {
+            addressLookup = new AddressLookupGoogleProxyService(options.googleProxy.findPromise, options.googleProxy.retrievePromise, options.googleProxy.findErrorCallback, options.googleProxy.retrieveErrorCallback);
         } else {
             v.prototype.$log.error(`You need to provide a Loqate Web Service, Google Maps API key or Proxies URL to Google.`);
         }


### PR DESCRIPTION
<!--
Veuillez consulter les directives de contribution / Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

## Description
Le proxy google pour le composant adresse prends une promise plutôt qu'un URL, ainsi il est possible d'ajouter des headers custom dans sa requête (notamment l'authentification).

## Types de changements
<!--- Indiquez ici quels types de modifications votre code introduit / Indicated here what types of changes does your code introduce -->
- [ ] Correction de bug (sans `breaking change`)
- [x] Amélioration (ajout par example une nouvelle propriété, évènement, slot ou méthode à un composant existant sans `breaking change`)
- [ ] Nouvelle fonctionalité (nouveau composant, directive, filtre ou service)
- [x] Breaking change (modification à une fonctionnalités existante qui nécessite une migration *remplir la section release note*)
- [ ] Refactoring/ménage (sans `breaking change`)
- [ ] Documentation/storybook (changement à la documentation ou aux storybooks qui n'affecte aucun package)
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Comment cela peut-il être testé?
<!--- Décrivez comment vous avez testé vos modifications / Please describe how you tested your changes -->
- [ ] Test unitaire (un nouveau test unitaire à été fait)
- [ ] Storybook
- [ ] Test manuel / Sandboxes
- [x] Autre
Dans ma branche Brio ENA2-8168

## Inclure cette section dans les release notes
Address Lookup Google Proxy service needs a Promise instead of a URL..

## Liens internes
https://jira.dti.ulaval.ca/browse/MODUL-1204
https://jira.dti.ulaval.ca/browse/ENA2-8168

<!--  Merci d'avoir contribué! / Thanks for contributing! -->
