### PR TITLE
ENA2-8551 - ajout retrait srcset sur les images dans froala

### DIFF
--- a/packages/modul-components/src/components/rich-text-editor/adapter/vue-froala.ts
+++ b/packages/modul-components/src/components/rich-text-editor/adapter/vue-froala.ts
@@ -1,13 +1,15 @@
 // This code is largery borrowed from https://github.com/froala/vue-froala-wysiwyg.
 // However some changes have been made to "inputify" the froala editor and render is compatible with modUL input-style.
-import FroalaEditor from 'froala-editor';
 import 'froala-editor/css/froala_editor.pkgd.min.css';
 import 'froala-editor/css/froala_style.min.css';
 import 'froala-editor/js/languages/fr.js';
 import 'froala-editor/js/plugins.pkgd.min.js';
+
+import FroalaEditor from 'froala-editor';
 import $ from 'jquery';
 import Component from 'vue-class-component';
 import { Emit, Prop, Watch } from 'vue-property-decorator';
+
 import boldIcon from '../../../assets/icons/svg/Froala-bold.svg';
 import listsIcon from '../../../assets/icons/svg/Froala-lists.svg';
 import replaceIcon from '../../../assets/icons/svg/Froala-replace.svg';
@@ -21,6 +23,7 @@ import uuid from '../../../utils/uuid/uuid';
 import { ModulVue } from '../../../utils/vue/vue';
 import { ImageLayoutCommands } from './image-layout-commands';
 import WithRender from './vue-froala.html?style=./vue-froala.scss';
+
 // import { PopupPlugin } from './popup-plugin';
 // import SubMenuPlugin from './submenu-plugin';
 // Bug placeholder in the version 3.0.5.
@@ -220,6 +223,7 @@ const SCROLL_TO_OFFSET: number = -50;
         this.$emit('image-added', files[0], (file: MFile, id: string) => {
             if (this.selectedImage) {
                 // Bug watch "JQuery dependence isn't fully removed from Froala" https://github.com/froala/angular-froala-wysiwyg/issues/324
+                this.selectedImage.removeAttribute('srcset');
                 this.froalaEditor.image.insert(file.url, false, { id }, $(this.selectedImage)); // We need jquery for that function
             } else {
                 this.froalaEditor.image.insert(file.url, false, { id });

--- a/packages/modul-components/src/components/rich-text-editor/adapter/vue-froala.ts
+++ b/packages/modul-components/src/components/rich-text-editor/adapter/vue-froala.ts
@@ -24,6 +24,8 @@ import { ModulVue } from '../../../utils/vue/vue';
 import { ImageLayoutCommands } from './image-layout-commands';
 import WithRender from './vue-froala.html?style=./vue-froala.scss';
 
+
+
 // import { PopupPlugin } from './popup-plugin';
 // import SubMenuPlugin from './submenu-plugin';
 // Bug placeholder in the version 3.0.5.
@@ -223,8 +225,8 @@ const SCROLL_TO_OFFSET: number = -50;
         this.$emit('image-added', files[0], (file: MFile, id: string) => {
             if (this.selectedImage) {
                 // Bug watch "JQuery dependence isn't fully removed from Froala" https://github.com/froala/angular-froala-wysiwyg/issues/324
-                this.selectedImage.removeAttribute('srcset');
                 this.froalaEditor.image.insert(file.url, false, { id }, $(this.selectedImage)); // We need jquery for that function
+                this.selectedImage.removeAttribute('srcset');
             } else {
                 this.froalaEditor.image.insert(file.url, false, { id });
             }


### PR DESCRIPTION
<!--
Veuillez consulter les directives de contribution / Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Content can be written in English or in French
-->

## Description
Retirer l'attribut srcset lors du remplacement d'une image dans le RTE.

## Types de changements
<!--- Indiquez ici quels types de modifications votre code introduit / Indicated here what types of changes does your code introduce -->
- [ ] Correction de bug (sans `breaking change`)
- [x] Amélioration (ajout par example une nouvelle propriété, évènement, slot ou méthode à un composant existant sans `breaking change`)
- [ ] Nouvelle fonctionalité (nouveau composant, directive, filtre ou service)
- [ ] Breaking change (modification à une fonctionnalités existante qui nécessite une migration *remplir la section release note*)
- [ ] Refactoring/ménage (sans `breaking change`)
- [ ] Documentation/storybook (changement à la documentation ou aux storybooks qui n'affecte aucun package)
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Comment cela peut-il être testé?
<!--- Décrivez comment vous avez testé vos modifications / Please describe how you tested your changes -->
- [ ] Test unitaire (un nouveau test unitaire à été fait)
- [ ] Storybook
- [ ] Test manuel / Sandboxes
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Inclure cette section dans les release notes
<!-- Pour chaque breaking changes , inscrire la description du changement et les instructions pour la migration -->

## Liens internes
https://jira.dti.ulaval.ca/browse/ENA2-8551

<!--  Merci d'avoir contribué! / Thanks for contributing! -->
