### PR TITLE
[f-m-date] Fixer l'erreur de formatage de l'heure pour fr-CA.

### DIFF
--- a/packages/modul-components/src/filters/date/time/time.ts
+++ b/packages/modul-components/src/filters/date/time/time.ts
@@ -1,6 +1,6 @@
 // tslint:disable-next-line: import-blacklist
 import 'moment/locale/fr';
-import Vue, { PluginObject } from 'vue';
+import { PluginObject } from 'vue';
 import { FormatMode } from '../../../utils/i18n/i18n';
 import { ModulVue } from '../../../utils/vue/vue';
 import { TIME_NAME, TIME_PERIOD_NAME } from '../../filter-names';
@@ -77,7 +77,14 @@ export const timeFilter: (time: SupportedTimeTypes, options?: TimeFilterOptions)
             minute: date.getMinutes() !== 0 ? 'numeric' : undefined
         };
 
-        const formatedTime: string = new Intl.DateTimeFormat(`${(Vue.prototype as ModulVue).$i18n.currentLocale}`, intlOptions).format(date).replace(/ /g, String.fromCharCode(160));
+        let formatedTime: string = new Intl.DateTimeFormat(ModulVue.prototype.$i18n.currentLocale, intlOptions).format(date)
+            .replace(/ /g, String.fromCharCode(160));
+
+        // Remove when https://bugs.chromium.org/p/chromium/issues/detail?id=982778#c3 is fixed.
+        if (ModulVue.prototype.$i18n.currentLocale === 'fr-CA' && formatedTime.match(/(0)[0-9]\sh\s*[0-9]*[0-9]*/g)) {
+            formatedTime = formatedTime.substr(1, formatedTime.length);
+        }
+
         return ModulVue.prototype.$i18n.translate(prepositionToTrad[options.preposition], { time: formatedTime }, 0, '', true, FormatMode.Vsprintf);
     }
     return '';


### PR DESCRIPTION
<!--
Veuillez consulter les directives de contribution / Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Content can be written in English or in French
-->

## Description
Il y a une erreur de formatage d'heure dans les browsers modernes.  Il ne devrait pas y avoir de traling 0s quand on  formate une heure en fr_CA.

https://bugs.chromium.org/p/chromium/issues/detail?id=982778#c3
Faudrait probablement ouvrir un bug sur mozilla aussi.

## Types de changements
<!--- Indiquez ici quels types de modifications votre code introduit / Indicated here what types of changes does your code introduce -->
- [x] Correction de bug (sans `breaking change`)
- [ ] Amélioration (ajout par example une nouvelle propriété, évènement, slot ou méthode à un composant existant sans `breaking change`)
- [ ] Nouvelle fonctionalité (nouveau composant, directive, filtre ou service)
- [ ] Breaking change (modification à une fonctionnalités existante qui nécessite une migration *remplir la section release note*)
- [ ] Refactoring/ménage (sans `breaking change`)
- [ ] Documentation/storybook (changement à la documentation ou aux storybooks qui n'affecte aucun package)
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Comment cela peut-il être testé?
<!--- Décrivez comment vous avez testé vos modifications / Please describe how you tested your changes -->
- [ ] Test unitaire (un nouveau test unitaire à été fait)
- [x] Storybook
- [ ] Test manuel / Sandboxes
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Inclure cette section dans les release notes
<!-- Pour chaque breaking changes , inscrire la description du changement et les instructions pour la migration -->

## Liens internes
<!-- Si vous êtes un contributeur interne, ajouter les liens vers vos billets Jira. ou déploiement dans openshift -->

<!--  Merci d'avoir contribué! / Thanks for contributing! -->
