### PR TITLE
[m-expendable-layout] Ajout prop overContent dans le m-expendable-layout

### DIFF
--- a/packages/modul-components/src/components/expandable-layout/expandable-layout.html
+++ b/packages/modul-components/src/components/expandable-layout/expandable-layout.html
@@ -1,11 +1,11 @@
 <div class="m-expandable-layout"
-     :class="panelPositionClass">
+     :class="styleClasses">
     <div class="m-expandable-layout__main">
         <slot></slot>
     </div>
     <div class="m-expandable-layout__panel"
          :style="panelStyle">
-        <div class="m-expandable-layout__panel__content"
+        <div class="m-expandable-layout__panel-content"
              :style="panelContentStyle"
              ref="panelContent">
             <slot name="panel"></slot>

--- a/packages/modul-components/src/components/expandable-layout/expandable-layout.scss
+++ b/packages/modul-components/src/components/expandable-layout/expandable-layout.scss
@@ -24,7 +24,6 @@
             &__panel {
                 position: absolute;
                 top: 0;
-                z-index: 2;
                 max-height: 100%;
                 overflow-y: auto;
 

--- a/packages/modul-components/src/components/expandable-layout/expandable-layout.scss
+++ b/packages/modul-components/src/components/expandable-layout/expandable-layout.scss
@@ -1,6 +1,54 @@
 @import 'commons';
 
 .m-expandable-layout {
+    &.m--is-panel-over-content {
+        position: relative;
+
+        &.m--has-left-panel {
+            .m-expandable-layout {
+                &__panel {
+                    left: 0;
+                }
+            }
+        }
+
+        &.m--has-right-panel {
+            .m-expandable-layout {
+                &__panel {
+                    right: 0;
+                }
+            }
+        }
+
+        .m-expandable-layout {
+            &__panel {
+                position: absolute;
+                top: 0;
+                z-index: 2;
+                max-height: 100%;
+                overflow-y: auto;
+
+                @include m-scrollbar();
+            }
+        }
+    }
+
+    &:not(.m--is-panel-over-content) {
+        .m-expandable-layout {
+            &__panel {
+                position: relative;
+            }
+
+            &__panel-content {
+                position: absolute;
+                top: 0;
+                left: 0;
+                right: 0;
+                bottom: 0;
+            }
+        }
+    }
+
     &.m--has-left-panel {
         display: grid;
         grid-template-areas: 'panel main';
@@ -13,24 +61,21 @@
         grid-template-columns: 1fr auto;
     }
 
-    &__main {
-        grid-area: main;
-    }
+    .m-expandable-layout {
+        &__main {
+            grid-area: main;
+        }
 
-    &__panel {
-        grid-area: panel;
-        overflow: hidden;
-        position: relative;
-        transition: width $m-transition-duration ease;
+        &__panel {
+            grid-area: panel;
+            overflow: hidden;
+            position: relative;
+            transition: width $m-transition-duration ease;
+        }
 
-        &__content {
+        &__panel-content {
             overflow-x: hidden;
             overflow-y: auto;
-            position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            bottom: 0;
 
             @include m-scrollbar();
         }

--- a/packages/modul-components/src/components/expandable-layout/expandable-layout.ts
+++ b/packages/modul-components/src/components/expandable-layout/expandable-layout.ts
@@ -43,6 +43,9 @@ export class MExpandableLayout extends ModulVue {
     @Prop({ default: '320px' })
     panelWidth: string;
 
+    @Prop({ default: false })
+    overContent: boolean;
+
     $refs: {
         panelContent: HTMLDivElement
     };
@@ -81,8 +84,12 @@ export class MExpandableLayout extends ModulVue {
         }
     }
 
-    get panelPositionClass(): string {
-        return this.$slots.panel ? `m--has-${this.panelPosition}-panel` : '';
+    get styleClasses(): { [key: string]: boolean } {
+        return {
+            'm--has-left-panel': !!this.$slots.panel && this.panelPosition === MExpandableLayoutPanelPosition.Left,
+            'm--has-right-panel': !!this.$slots.panel && this.panelPosition === MExpandableLayoutPanelPosition.Right,
+            'm--is-panel-over-content': this.overContent
+        };
     }
 
     get panelStyle(): { [prop: string]: string } {

--- a/src/storybook/src/modul-components/components/expandable-layout/__snapshots__/expandable-layout.stories.ts.snap
+++ b/src/storybook/src/modul-components/components/expandable-layout/__snapshots__/expandable-layout.stories.ts.snap
@@ -3,7 +3,6 @@
 exports[`Storyshots modul-components|m-expandable-layout default 1`] = `
 <div
   class="m-expandable-layout m--has-left-panel"
-  style="background: yellow;"
 >
   <div
     class="m-expandable-layout__main"
@@ -21,11 +20,11 @@ exports[`Storyshots modul-components|m-expandable-layout default 1`] = `
     style="width: 320px;"
   >
     <div
-      class="m-expandable-layout__panel__content"
+      class="m-expandable-layout__panel-content"
       style="width: 320px;"
     >
       <div
-        style="height: 300vh;"
+        style="background: yellow; height: 300vh;"
       >
         panel content
       </div>
@@ -55,7 +54,7 @@ exports[`Storyshots modul-components|m-expandable-layout open 1`] = `
     style="width: 320px;"
   >
     <div
-      class="m-expandable-layout__panel__content"
+      class="m-expandable-layout__panel-content"
       style="width: 320px;"
     >
       panel content
@@ -85,7 +84,7 @@ exports[`Storyshots modul-components|m-expandable-layout panel-position="right" 
     style="width: 320px;"
   >
     <div
-      class="m-expandable-layout__panel__content"
+      class="m-expandable-layout__panel-content"
       style="width: 320px;"
     >
       panel content
@@ -115,7 +114,7 @@ exports[`Storyshots modul-components|m-expandable-layout panel-width="600px" 1`]
     style="width: 600px;"
   >
     <div
-      class="m-expandable-layout__panel__content"
+      class="m-expandable-layout__panel-content"
       style="width: 600px;"
     >
       panel content
@@ -143,7 +142,7 @@ exports[`Storyshots modul-components|m-expandable-layout without panel slot 1`] 
     class="m-expandable-layout__panel"
   >
     <div
-      class="m-expandable-layout__panel__content"
+      class="m-expandable-layout__panel-content"
     />
   </div>
 </div>

--- a/src/storybook/src/modul-components/components/expandable-layout/expandable-layout.stories.ts
+++ b/src/storybook/src/modul-components/components/expandable-layout/expandable-layout.stories.ts
@@ -26,12 +26,15 @@ storiesOf(`${modulComponentsHierarchyRootSeparator}${EXPANDABLE_LAYOUT_NAME}`, m
             },
             panelContentHeight: {
                 default: text('simulated panel content height', '300vh')
+            },
+            overContent: {
+                default: boolean('over-content', false)
             }
         },
         template: `
-        <m-expandable-layout :open="open" :panel-scroll-mode="panelScrollMode" :panel-position="panelPosition" :panel-width="panelWidth" style="background: yellow;">
+        <m-expandable-layout :open="open" :panel-scroll-mode="panelScrollMode" :panel-position="panelPosition" :panel-width="panelWidth" :over-content="overContent">
             <div :style="{background: 'lightgrey', height: mainContentHeight}">main content</div>
-            <div slot="panel" :style="{height: panelContentHeight}">panel content</div>
+            <div slot="panel" :style="{height: panelContentHeight}" style="background: yellow;">panel content</div>
         </m-expandable-layout>`
     }))
     .add('open', () => ({


### PR DESCRIPTION
<!--
Veuillez consulter les directives de contribution / Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Content can be written in English or in French
-->

## Description
Ajout d'une prop overContent pour que le panel passe par dessus le contenu

## Types de changements
<!--- Indiquez ici quels types de modifications votre code introduit / Indicated here what types of changes does your code introduce -->
- [ ] Correction de bug (sans `breaking change`)
- [x] Amélioration (ajout par example une nouvelle propriété, évènement, slot ou méthode à un composant existant sans `breaking change`)
- [ ] Nouvelle fonctionalité (nouveau composant, directive, filtre ou service)
- [ ] Breaking change (modification à une fonctionnalités existante qui nécessite une migration *remplir la section release note*)
- [ ] Refactoring/ménage (sans `breaking change`)
- [ ] Documentation/storybook (changement à la documentation ou aux storybooks qui n'affecte aucun package)
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Comment cela peut-il être testé?
<!--- Décrivez comment vous avez testé vos modifications / Please describe how you tested your changes -->
- [ ] Test unitaire (un nouveau test unitaire à été fait)
- [x] Storybook
- [ ] Test manuel / Sandboxes
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Inclure cette section dans les release notes
<!-- Pour chaque breaking changes , inscrire la description du changement et les instructions pour la migration -->

## Liens internes
[https://jira.dti.ulaval.ca/browse/ENA2-8583](https://jira.dti.ulaval.ca/browse/ENA2-8583)

<!--  Merci d'avoir contribué! / Thanks for contributing! -->
