### PR TITLE
[m-inplace-edit] Enlever velop en trop

### DIFF
--- a/packages/modul-components/src/components/inplace-edit/inplace-edit.html
+++ b/packages/modul-components/src/components/inplace-edit/inplace-edit.html
@@ -39,7 +39,7 @@
                    @close="onCancel"
                    @save="onConfirm"
                    @portal-after-open="emitMobileAfterOpen"
-                   @portal-after-close="emitMobileAfterClose">velop
+                   @portal-after-close="emitMobileAfterClose">
             <h2 class="m-edit-inplace__title"
                 slot="header">{{ title }}</h2>
             <form>


### PR DESCRIPTION
<!--
Veuillez consulter les directives de contribution / Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Content can be written in English or in French
-->

## Description
Dans le inplace-edit il y a maintenant un "velop" en trop qui apparaît.  Je pense que c'est p-e une erreur de merge.

## Types de changements
<!--- Indiquez ici quels types de modifications votre code introduit / Indicated here what types of changes does your code introduce -->
- [x] Correction de bug (sans `breaking change`)
- [ ] Amélioration (ajout par example une nouvelle propriété, évènement, slot ou méthode à un composant existant sans `breaking change`)
- [ ] Nouvelle fonctionalité (nouveau composant, directive, filtre ou service)
- [ ] Breaking change (modification à une fonctionnalités existante qui nécessite une migration *remplir la section release note*)
- [ ] Refactoring/ménage (sans `breaking change`)
- [ ] Documentation/storybook (changement à la documentation ou aux storybooks qui n'affecte aucun package)
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Comment cela peut-il être testé?
<!--- Décrivez comment vous avez testé vos modifications / Please describe how you tested your changes -->
- [ ] Test unitaire (un nouveau test unitaire à été fait)
- [x] Storybook
- [ ] Test manuel / Sandboxes
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Inclure cette section dans les release notes
<!-- Pour chaque breaking changes , inscrire la description du changement et les instructions pour la migration -->

## Liens internes
https://jira.dti.ulaval.ca/browse/ENA2-9032

<!--  Merci d'avoir contribué! / Thanks for contributing! -->
