### PR TITLE
[m-adress-editor] Ajouter deux types de format d'adresse

### DIFF
--- a/packages/modul-components/src/components/address/address-editor/address-editor.html
+++ b/packages/modul-components/src/components/address/address-editor/address-editor.html
@@ -1,25 +1,36 @@
 <div class="m-address-editor">
-    <m-textfield :label="i18nBuildingNumber"
-                 :value="buildingNumber"
-                 :error="buildingNumberHasError"
-                 :error-message="buildingNumberNextError"
-                 @input="onBuildingNumberChange"></m-textfield><br />
-    <m-textfield :label="i18nSubBuilding"
-                 :value="subBuilding"
-                 :error="subBuildingHasError"
-                 :error-message="subBuildingNextError"
-                 @input="onSubBuildingChange"></m-textfield><br />
-    <m-textfield :label="i18nStreet"
-                 :value="street"
-                 :error="streetHasError"
-                 :error-message="streetNextError"
-                 @input="onStreetChange"></m-textfield><br />
+
+    <template v-if="isDetailAdressFormat">
+        <m-textfield :label="i18nBuildingNumber"
+                     :value="buildingNumber"
+                     :error="buildingNumberHasError"
+                     :error-message="buildingNumberNextError"
+                     @input="onBuildingNumberChange"></m-textfield>
+        <m-textfield :label="i18nSubBuilding"
+                     :value="subBuilding"
+                     :error="subBuildingHasError"
+                     :error-message="subBuildingNextError"
+                     @input="onSubBuildingChange"></m-textfield>
+        <m-textfield :label="i18nStreet"
+                     :value="street"
+                     :error="streetHasError"
+                     :error-message="streetNextError"
+                     @input="onStreetChange"></m-textfield>
+    </template>
+
+    <template v-else>
+        <m-textfield :label="i18nLine1"
+                     :value="Line1"
+                     :error="Line1HasError"
+                     :error-message="Line1NextError"
+                     @input="onLine1Change"></m-textfield>
+    </template>
 
     <m-textfield :label="i18nCity"
                  :value="city"
                  :error="cityHasError"
                  :error-message="cityNextError"
-                 @input="onCityChange"></m-textfield><br />
+                 @input="onCityChange"></m-textfield>
 
     <m-dropdown :label="i18nCountry"
                 :value="country"
@@ -30,23 +41,23 @@
                          :key="country.countryIso2"
                          :value="country.countryIso2"
                          :label="country.country"></m-dropdown-item>
-    </m-dropdown><br />
+    </m-dropdown>
 
-    <div v-if="provinces.length > 0">
-        <m-dropdown :label="i18nProvince"
-                    :value="province"
-                    :error="provinceHasError"
-                    :error-message="provinceNextError"
-                    @change="onProvinceChange">
-            <m-dropdown-item v-for="province in provinces"
-                             :key="province.provinceCode"
-                             :value="province.provinceCode"
-                             :label="province.province"></m-dropdown-item>
-        </m-dropdown><br />
-    </div>
+    <m-dropdown v-if="provinces.length > 0"
+                :label="i18nProvince"
+                :value="province"
+                :error="provinceHasError"
+                :error-message="provinceNextError"
+                @change="onProvinceChange">
+        <m-dropdown-item v-for="province in provinces"
+                         :key="province.provinceCode"
+                         :value="province.provinceCode"
+                         :label="province.province"></m-dropdown-item>
+    </m-dropdown>
+
     <m-textfield :label="i18nPostalCode"
                  :value="postalCode"
                  :error="postalCodeHasError"
                  :error-message="postalCodeNextError"
-                 @input="onPostalCodeChange"></m-textfield><br />
+                 @input="onPostalCodeChange"></m-textfield>
 </div>

--- a/packages/modul-components/src/components/address/address-editor/address-editor.lang.en.json
+++ b/packages/modul-components/src/components/address/address-editor/address-editor.lang.en.json
@@ -1,11 +1,12 @@
 {
     "m-address-editor": {
         "building-number": "Building number",
-        "sub-building": "Unit",
-        "street": "Street",
         "city": "City",
         "country": "Country",
+        "line-1": "Adress",
+        "postal-code": "Postal Code",
         "province": "Province / state",
-        "postal-code": "Postal Code"
+        "street": "Street",
+        "sub-building": "Unit"
     }
 }

--- a/packages/modul-components/src/components/address/address-editor/address-editor.lang.fr.json
+++ b/packages/modul-components/src/components/address/address-editor/address-editor.lang.fr.json
@@ -1,11 +1,12 @@
 {
     "m-address-editor": {
         "building-number": "Numéro civique",
-        "sub-building": "Unité",
-        "street": "Rue",
         "city": "Ville",
         "country": "Pays",
+        "line-1": "Adresse",
+        "postal-code": "Code Postal",
         "province": "Province / état",
-        "postal-code": "Code Postal"
+        "street": "Rue",
+        "sub-building": "Unité"
     }
 }

--- a/packages/modul-components/src/components/address/address-editor/address-editor.ts
+++ b/packages/modul-components/src/components/address/address-editor/address-editor.ts
@@ -1,6 +1,6 @@
 import Component from 'vue-class-component';
 import { Emit, Model, Prop, Watch } from 'vue-property-decorator';
-import { Address, AddressField, copyAddress, Country, CountryKey, Province } from '../../../utils/address-lookup/address';
+import { Address, AddressField, AddressFormat, copyAddress, Country, CountryKey, Province } from '../../../utils/address-lookup/address';
 import { ModulVue } from '../../../utils/vue/vue';
 import { MDropdown } from '../../dropdown/dropdown';
 import { MTextfield } from '../../textfield/textfield';
@@ -33,17 +33,23 @@ export default class MAddressEditor extends ModulVue {
     @Prop({ default: () => ({}) })
     validations: { [field: string]: AddressEditorValidator[] };
 
+    @Prop({
+        default: AddressFormat.DETAILS_FIELDS
+    })
+    adressFormat: AddressFormat;
+
     i18nBuildingNumber: string = this.$i18n.translate('m-address-editor:building-number');
-    i18nSubBuilding: string = this.$i18n.translate('m-address-editor:sub-building');
-    i18nStreet: string = this.$i18n.translate('m-address-editor:street');
     i18nCity: string = this.$i18n.translate('m-address-editor:city');
     i18nCountry: string = this.$i18n.translate('m-address-editor:country');
-    i18nProvince: string = this.$i18n.translate('m-address-editor:province');
+    i18nLine1: string = this.$i18n.translate('m-address-editor:line-1');
     i18nPostalCode: string = this.$i18n.translate('m-address-editor:postal-code');
+    i18nProvince: string = this.$i18n.translate('m-address-editor:province');
+    i18nStreet: string = this.$i18n.translate('m-address-editor:street');
+    i18nSubBuilding: string = this.$i18n.translate('m-address-editor:sub-building');
 
 
     currentAddress: Address = copyAddress(this.address);
-    private errors: { [field: string]: string[] } = {
+    private errorsDeteilsFields: { [field: string]: string[] } = {
         [AddressField.BUILDING_NUMBER]: [],
         [AddressField.STREET]: [],
         [AddressField.SUB_BUILDING]: [],
@@ -53,10 +59,26 @@ export default class MAddressEditor extends ModulVue {
         [AddressField.POSTAL_CODE]: []
     };
 
-    private touched: { [field: string]: boolean } = {
+    private errorsFormatedFields: { [field: string]: string[] } = {
+        [AddressField.LINE_1]: [],
+        [AddressField.CITY]: [],
+        [AddressField.PROVINCE]: [],
+        [AddressField.COUNTRY]: [],
+        [AddressField.POSTAL_CODE]: []
+    };
+
+    private touchedDeteilsFields: { [field: string]: boolean } = {
         [AddressField.BUILDING_NUMBER]: false,
         [AddressField.STREET]: false,
         [AddressField.SUB_BUILDING]: false,
+        [AddressField.CITY]: false,
+        [AddressField.PROVINCE]: false,
+        [AddressField.COUNTRY]: false,
+        [AddressField.POSTAL_CODE]: false
+    };
+
+    private touchedFormatedFields: { [field: string]: boolean } = {
+        [AddressField.LINE_1]: false,
         [AddressField.CITY]: false,
         [AddressField.PROVINCE]: false,
         [AddressField.COUNTRY]: false,
@@ -78,6 +100,18 @@ export default class MAddressEditor extends ModulVue {
         this.validate(AddressField.PROVINCE);
     }
 
+    get isDetailAdressFormat(): boolean {
+        return this.adressFormat === AddressFormat.DETAILS_FIELDS;
+    }
+
+    get errors(): { [field: string]: string[] } {
+        return this.isDetailAdressFormat ? this.errorsDeteilsFields : this.errorsFormatedFields;
+    }
+
+    get touched(): { [field: string]: boolean } {
+        return this.isDetailAdressFormat ? this.touchedDeteilsFields : this.touchedFormatedFields;
+    }
+
     onBuildingNumberChange(value: string): void {
         this.touched[AddressField.BUILDING_NUMBER] = true;
         this.validate(AddressField.BUILDING_NUMBER, value);
@@ -85,7 +119,7 @@ export default class MAddressEditor extends ModulVue {
     }
 
     get buildingNumber(): string {
-        return this.currentAddress.buildingNumber;
+        return this.currentAddress.buildingNumber ? this.currentAddress.buildingNumber : '';
     }
 
     get buildingNumberHasError(): boolean {
@@ -106,7 +140,7 @@ export default class MAddressEditor extends ModulVue {
     }
 
     get street(): string {
-        return this.currentAddress.street;
+        return this.currentAddress.street ? this.currentAddress.street : '';
     }
 
     get streetHasError(): boolean {
@@ -127,7 +161,7 @@ export default class MAddressEditor extends ModulVue {
     }
 
     get subBuilding(): string {
-        return this.currentAddress.subBuilding;
+        return this.currentAddress.subBuilding ? this.currentAddress.subBuilding : '';
     }
 
     get subBuildingHasError(): boolean {
@@ -230,6 +264,27 @@ export default class MAddressEditor extends ModulVue {
     get cityNextError(): string {
         if (this.cityHasError) {
             return this.errors[AddressField.CITY][0];
+        }
+        return '';
+    }
+
+    onLine1Change(value: string): void {
+        this.touched[AddressField.LINE_1] = true;
+        this.validate(AddressField.LINE_1, value);
+        this.updateValue(AddressField.LINE_1, value);
+    }
+
+    get Line1(): string {
+        return this.currentAddress.buildingNumber ? this.currentAddress.buildingNumber : '';
+    }
+
+    get Line1HasError(): boolean {
+        return !!this.errors[AddressField.LINE_1] && this.errors[AddressField.LINE_1].length > 0;
+    }
+
+    get Line1NextError(): string {
+        if (this.Line1HasError) {
+            return this.errors[AddressField.LINE_1][0];
         }
         return '';
     }

--- a/packages/modul-components/src/utils/address-lookup/address.ts
+++ b/packages/modul-components/src/utils/address-lookup/address.ts
@@ -14,13 +14,14 @@ export interface AddressSummary {
 export interface Address {
     id: string;
     name: string;
-    buildingNumber: string;
-    street: string;
+    buildingNumber?: string;
+    street?: string;
+    line1?: string;
     city: string;
     province?: Province;
     postalCode: string;
     country: Country;
-    subBuilding: string;
+    subBuilding?: string;
     formattedAddress: string;
     adrFormattedAddress: string;
     attributions: string[];
@@ -38,10 +39,16 @@ export interface Country {
     countryIso2: string;
 }
 
+export enum AddressFormat {
+    DETAILS_FIELDS = 'detailsFields',
+    FORMATED_FIELDS = 'formatedFields'
+}
+
 export enum AddressField {
     BUILDING_NUMBER = 'buildingNumber',
     STREET = 'street',
     CITY = 'city',
+    LINE_1 = 'line1',
     POSTAL_CODE = 'postalCode',
     SUB_BUILDING = 'subBuilding',
     COUNTRY = 'country',

--- a/src/storybook/src/modul-components/components/address/address-editor/__snapshots__/address-editor.stories.ts.snap
+++ b/src/storybook/src/modul-components/components/address/address-editor/__snapshots__/address-editor.stories.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots modul-components|/m-address/m-address-editor default 1`] = `
+exports[`Storyshots modul-components|/m-address/m-address-editor Default 1`] = `
 <div>
   <div>
     <div
@@ -86,7 +86,6 @@ exports[`Storyshots modul-components|/m-address/m-address-editor default 1`] = `
           <!---->
         </div>
       </div>
-      <br />
        
       <div
         class="m-textfield m--has-label m--is-type-text"
@@ -168,7 +167,6 @@ exports[`Storyshots modul-components|/m-address/m-address-editor default 1`] = `
           <!---->
         </div>
       </div>
-      <br />
        
       <div
         class="m-textfield m--has-label m--is-type-text"
@@ -250,7 +248,6 @@ exports[`Storyshots modul-components|/m-address/m-address-editor default 1`] = `
           <!---->
         </div>
       </div>
-      <br />
        
       <div
         class="m-textfield m--has-label m--is-type-text"
@@ -332,7 +329,6 @@ exports[`Storyshots modul-components|/m-address/m-address-editor default 1`] = `
           <!---->
         </div>
       </div>
-      <br />
        
       <div
         class="m-dropdown"
@@ -441,7 +437,6 @@ exports[`Storyshots modul-components|/m-address/m-address-editor default 1`] = `
           <!---->
         </div>
       </div>
-      <br />
        
       <!---->
        
@@ -525,7 +520,6 @@ exports[`Storyshots modul-components|/m-address/m-address-editor default 1`] = `
           <!---->
         </div>
       </div>
-      <br />
     </div>
   </div>
    
@@ -557,7 +551,7 @@ exports[`Storyshots modul-components|/m-address/m-address-editor default 1`] = `
 </div>
 `;
 
-exports[`Storyshots modul-components|/m-address/m-address-editor empty address 1`] = `
+exports[`Storyshots modul-components|/m-address/m-address-editor Empty address 1`] = `
 <div>
   <div>
     <div
@@ -643,7 +637,6 @@ exports[`Storyshots modul-components|/m-address/m-address-editor empty address 1
           <!---->
         </div>
       </div>
-      <br />
        
       <div
         class="m-textfield m--has-label m--is-type-text"
@@ -725,7 +718,6 @@ exports[`Storyshots modul-components|/m-address/m-address-editor empty address 1
           <!---->
         </div>
       </div>
-      <br />
        
       <div
         class="m-textfield m--has-label m--is-type-text"
@@ -807,7 +799,6 @@ exports[`Storyshots modul-components|/m-address/m-address-editor empty address 1
           <!---->
         </div>
       </div>
-      <br />
        
       <div
         class="m-textfield m--has-label m--is-type-text"
@@ -889,7 +880,6 @@ exports[`Storyshots modul-components|/m-address/m-address-editor empty address 1
           <!---->
         </div>
       </div>
-      <br />
        
       <div
         class="m-dropdown"
@@ -998,7 +988,6 @@ exports[`Storyshots modul-components|/m-address/m-address-editor empty address 1
           <!---->
         </div>
       </div>
-      <br />
        
       <!---->
        
@@ -1082,7 +1071,6 @@ exports[`Storyshots modul-components|/m-address/m-address-editor empty address 1
           <!---->
         </div>
       </div>
-      <br />
     </div>
   </div>
    
@@ -1100,6 +1088,385 @@ exports[`Storyshots modul-components|/m-address/m-address-editor empty address 1
   "postalCode": "",
   "subBuilding": ""
 }
+  </div>
+</div>
+`;
+
+exports[`Storyshots modul-components|/m-address/m-address-editor Formated adress type 1`] = `
+<div>
+  <div>
+    <div
+      class="m-address-editor"
+    >
+      <div
+        class="m-textfield m--has-label m--is-type-text"
+        style="width: 100%; max-width: 288px;"
+      >
+        <div
+          class="m-input-style m--has-label m--is-tag-default"
+          style="margin-top: 10px;"
+        >
+          <div
+            class="m-input-style__main"
+          >
+            <div
+              class="m-input-style__body"
+            >
+              <label
+                class="m-input-style__label"
+                for="mTextfield-fakeId"
+                style="margin-right: 0px;"
+              >
+                <span
+                  class="m-input-style__text"
+                >
+                  <span>
+                    Adresse
+                  </span>
+                   
+                  <!---->
+                </span>
+              </label>
+               
+              <div
+                class="m-input-style__input"
+              >
+                <!---->
+                 
+                <div
+                  class="m-input-style__content"
+                >
+                  <input
+                    class="m-textfield__input"
+                    id="mTextfield-fakeId"
+                    maxlength="Infinity"
+                    type="text"
+                  />
+                     
+                  <!---->
+                   
+                  <!---->
+                   
+                  <!---->
+                </div>
+                 
+                <div
+                  class="m-input-style__suffix"
+                >
+                  <!---->
+                   
+                  <!---->
+                </div>
+              </div>
+            </div>
+             
+            <!---->
+          </div>
+        </div>
+         
+        <div
+          class="m-textfield__validation"
+        >
+          <div
+            class="m-validation-message m-textfield__validation__message"
+          >
+            <!---->
+             
+            <!---->
+          </div>
+           
+          <!---->
+        </div>
+      </div>
+       
+      <div
+        class="m-textfield m--has-label m--is-type-text"
+        style="width: 100%; max-width: 288px;"
+      >
+        <div
+          class="m-input-style m--has-label m--is-tag-default"
+          style="margin-top: 10px;"
+        >
+          <div
+            class="m-input-style__main"
+          >
+            <div
+              class="m-input-style__body"
+            >
+              <label
+                class="m-input-style__label"
+                for="mTextfield-fakeId"
+                style="margin-right: 0px;"
+              >
+                <span
+                  class="m-input-style__text"
+                >
+                  <span>
+                    Ville
+                  </span>
+                   
+                  <!---->
+                </span>
+              </label>
+               
+              <div
+                class="m-input-style__input"
+              >
+                <!---->
+                 
+                <div
+                  class="m-input-style__content"
+                >
+                  <input
+                    class="m-textfield__input"
+                    id="mTextfield-fakeId"
+                    maxlength="Infinity"
+                    type="text"
+                  />
+                     
+                  <!---->
+                   
+                  <!---->
+                   
+                  <!---->
+                </div>
+                 
+                <div
+                  class="m-input-style__suffix"
+                >
+                  <!---->
+                   
+                  <!---->
+                </div>
+              </div>
+            </div>
+             
+            <!---->
+          </div>
+        </div>
+         
+        <div
+          class="m-textfield__validation"
+        >
+          <div
+            class="m-validation-message m-textfield__validation__message"
+          >
+            <!---->
+             
+            <!---->
+          </div>
+           
+          <!---->
+        </div>
+      </div>
+       
+      <div
+        class="m-dropdown"
+        style="width: 100%; max-width: 288px;"
+      >
+        <div
+          class="m-input-style m--is-label-up m--has-cursor-pointer m--has-label m--has-value m--is-tag-default"
+          style="width: 100%; margin-top: 10px;"
+        >
+          <div
+            class="m-input-style__main"
+          >
+            <div
+              class="m-input-style__body"
+            >
+              <label
+                class="m-input-style__label"
+                for="mDropdown-fakeId"
+                style="margin-right: 0px;"
+              >
+                <span
+                  class="m-input-style__text"
+                >
+                  <span>
+                    Pays
+                  </span>
+                   
+                  <!---->
+                </span>
+              </label>
+               
+              <div
+                class="m-input-style__input"
+              >
+                <!---->
+                 
+                <div
+                  class="m-input-style__content"
+                >
+                  <!---->
+                   
+                  <input
+                    aria-controls="mDropdown-fakeId-controls"
+                    aria-haspopup="true"
+                    class="m-dropdown__input"
+                    id="mDropdown-fakeId"
+                    readonly="readonly"
+                    type="text"
+                  />
+                   
+                  <!---->
+                    
+                  <!---->
+                   
+                  <!---->
+                </div>
+                 
+                <div
+                  class="m-input-style__suffix"
+                >
+                  <div
+                    class="m-dropdown__arrow"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="m-icon m-dropdown__arrow__icon"
+                      height="12px"
+                      width="12px"
+                    >
+                      <!---->
+                       
+                      <use
+                        aria-hidden="true"
+                        class=""
+                      />
+                    </svg>
+                  </div>
+                   
+                  <!---->
+                </div>
+              </div>
+            </div>
+             
+            <!---->
+          </div>
+        </div>
+         
+        <div
+          class="m-validation-message m-dropdown__validation-message"
+        >
+          <!---->
+           
+          <!---->
+        </div>
+         
+        <div
+          class="m-popup"
+        >
+          <div
+            class="m-popper"
+          >
+             
+            <!---->
+          </div>
+           
+          <!---->
+        </div>
+      </div>
+       
+      <!---->
+       
+      <div
+        class="m-textfield m--has-label m--is-type-text"
+        style="width: 100%; max-width: 288px;"
+      >
+        <div
+          class="m-input-style m--is-label-up m--has-label m--has-value m--is-tag-default"
+          style="margin-top: 10px;"
+        >
+          <div
+            class="m-input-style__main"
+          >
+            <div
+              class="m-input-style__body"
+            >
+              <label
+                class="m-input-style__label"
+                for="mTextfield-fakeId"
+                style="margin-right: 0px;"
+              >
+                <span
+                  class="m-input-style__text"
+                >
+                  <span>
+                    Code Postal
+                  </span>
+                   
+                  <!---->
+                </span>
+              </label>
+               
+              <div
+                class="m-input-style__input"
+              >
+                <!---->
+                 
+                <div
+                  class="m-input-style__content"
+                >
+                  <input
+                    class="m-textfield__input"
+                    id="mTextfield-fakeId"
+                    maxlength="Infinity"
+                    type="text"
+                  />
+                     
+                  <!---->
+                   
+                  <!---->
+                   
+                  <!---->
+                </div>
+                 
+                <div
+                  class="m-input-style__suffix"
+                >
+                  <!---->
+                   
+                  <!---->
+                </div>
+              </div>
+            </div>
+             
+            <!---->
+          </div>
+        </div>
+         
+        <div
+          class="m-textfield__validation"
+        >
+          <div
+            class="m-validation-message m-textfield__validation__message"
+          >
+            <!---->
+             
+            <!---->
+          </div>
+           
+          <!---->
+        </div>
+      </div>
+    </div>
+  </div>
+   
+  <div
+    style="border-top: 1px solid #000; margin-top: 50px;"
+  >
+    <div>
+      Address from editor : {
+  "line1": "",
+  "city": "",
+  "country": {
+    "country": "Canada",
+    "countryIso2": "CA"
+  },
+  "postalCode": "G1V 0A6"
+}
+    </div>
   </div>
 </div>
 `;

--- a/src/storybook/src/modul-components/components/address/address-editor/address-editor.stories.ts
+++ b/src/storybook/src/modul-components/components/address/address-editor/address-editor.stories.ts
@@ -2,7 +2,7 @@ import { storiesOf } from '@storybook/vue';
 import AddressPlugin from '@ulaval/modul-components/dist/components/address/address';
 import MAddressEditor, { AddressEditorValidator } from '@ulaval/modul-components/dist/components/address/address-editor/address-editor';
 import { ADDRESS_EDITOR_NAME } from '@ulaval/modul-components/dist/components/component-names';
-import { Address, AddressField, Country, Province } from '@ulaval/modul-components/dist/utils/address-lookup/address';
+import { Address, AddressField, AddressFormat, Country, Province } from '@ulaval/modul-components/dist/utils/address-lookup/address';
 import Vue from 'vue';
 import { modulComponentsHierarchyRootSeparator } from '../../../../utils';
 
@@ -116,11 +116,14 @@ const validations: { [field: string]: AddressEditorValidator[] } = {
     ],
     [AddressField.PROVINCE]: [
         (_value: string, context: Address, provinces: Province[]) => (context[AddressField.PROVINCE] === undefined && provinces.length > 0) ? 'Province is required' : ''
+    ],
+    [AddressField.LINE_1]: [
+        (value: string, _context: Address) => (value === '') ? 'Adress is required.' : ''
     ]
 };
 
 storiesOf(`${modulComponentsHierarchyRootSeparator}/m-address/${ADDRESS_EDITOR_NAME}`, module)
-    .add('default', () => ({
+    .add('Default', () => ({
         components: { MAddressEditor },
         data: () => ({
             address: {
@@ -174,7 +177,52 @@ storiesOf(`${modulComponentsHierarchyRootSeparator}/m-address/${ADDRESS_EDITOR_N
             </div>
         </div>`
     }))
-    .add('empty address', () => ({
+    .add('Formated adress type', () => ({
+        components: { MAddressEditor },
+        data: () => ({
+            address: {
+                line1: '',
+                city: '',
+                country: {
+                    country: 'Canada',
+                    countryIso2: 'CA'
+                },
+                province: undefined,
+                postalCode: 'G1V 0A6'
+            },
+            countries: countries,
+            provincesList: provinces,
+            currentProvinces: [],
+            validations,
+            adressFormat: AddressFormat.FORMATED_FIELDS
+        }),
+        mounted(): void {
+            this.onCountryChange(this.address.country.countryIso2);
+        },
+        methods: {
+            onCountryChange(code: string): void {
+                (this as any).currentProvinces = (this as any).provincesList[code];
+            }
+        },
+        template: `
+        <div>
+            <div>
+                <${ADDRESS_EDITOR_NAME} v-model='address'
+                                        :countries='countries'
+                                        :provinces='currentProvinces'
+                                        :validations='validations'
+                                        :adress-format='adressFormat'
+                                        @country-change='onCountryChange'
+                >
+                </${ADDRESS_EDITOR_NAME}>
+            </div>
+
+            <div style='border-top: 1px solid #000; margin-top: 50px;'>
+                <div>Address from editor : {{ address }}</div>
+            </div>
+        </div>`
+    }))
+    .add('Empty address', () => ({
         components: { MAddressEditor },
         data: () => ({
             address: {


### PR DESCRIPTION
<!--
Veuillez consulter les directives de contribution / Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Content can be written in English or in French
-->

## Description
Modifier le composant m-adress-editor pour permettre le type adresse avec une ligne pour adresse. Présentement il y a 3 champs soit numéro civique, nom de la rue et unité. 

## Types de changements
<!--- Indiquez ici quels types de modifications votre code introduit / Indicated here what types of changes does your code introduce -->
- [ ] Correction de bug (sans `breaking change`)
- [X] Amélioration (ajout par example une nouvelle propriété, évènement, slot ou méthode à un composant existant sans `breaking change`)
- [ ] Nouvelle fonctionalité (nouveau composant, directive, filtre ou service)
- [ ] Breaking change (modification à une fonctionnalités existante qui nécessite une migration *remplir la section release note*)
- [ ] Refactoring/ménage (sans `breaking change`)
- [X] Documentation/storybook (changement à la documentation ou aux storybooks qui n'affecte aucun package)
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Comment cela peut-il être testé?
<!--- Décrivez comment vous avez testé vos modifications / Please describe how you tested your changes -->
- [ ] Test unitaire (un nouveau test unitaire à été fait)
- [X] Storybook
- [ ] Test manuel / Sandboxes
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Inclure cette section dans les release notes
<!-- Pour chaque breaking changes , inscrire la description du changement et les instructions pour la migration -->

## Liens internes
https://jira.dti.ulaval.ca/browse/ENA2-10249

<!--  Merci d'avoir contribué! / Thanks for contributing! -->
