### PR TITLE
[m-postalcodefield] - Création du composant pour les champs code postal

### DIFF
--- a/packages/modul-components/src/components/component-names.ts
+++ b/packages/modul-components/src/components/component-names.ts
@@ -81,6 +81,7 @@ export const PHOTO_EDITOR_NAME: string = 'm-photo-editor';
 export const PLUS_NAME: string = 'm-plus';
 export const POPPER_NAME: string = 'm-popper';
 export const POPUP_NAME: string = 'm-popup';
+export const POSTALCODEFIELD_NAME: string = 'm-postalcodefield';
 export const POWERED_BY_GOOGLE: string = 'm-powered-by-google';
 export const PROGRESS_NAME: string = 'm-progress';
 export const RADIO_NAME: string = 'm-radio';

--- a/packages/modul-components/src/components/postalcodefield/postalcodefield.html
+++ b/packages/modul-components/src/components/postalcodefield/postalcodefield.html
@@ -1,0 +1,6 @@
+<m-maskedfield class="m-postalcodefield"
+               v-bind="bindData"
+               v-on="$listeners"
+               :id="id"
+               :mask-options="maskOptions">
+</m-maskedfield>

--- a/packages/modul-components/src/components/postalcodefield/postalcodefield.ts
+++ b/packages/modul-components/src/components/postalcodefield/postalcodefield.ts
@@ -54,11 +54,6 @@ export class MPostalcodefield extends ModulVue {
                     uppercase: true
                 };
             case MPostalCodeFormat.Other:
-                // Infinite value to display normaly with no space the default values if no blocks is specified!
-                return {
-                    blocks: [1e+23],
-                    uppercase: true
-                };
             default:
                 // Infinite value to display normaly with no space the default values if no blocks is specified!
                 return {

--- a/packages/modul-components/src/components/postalcodefield/postalcodefield.ts
+++ b/packages/modul-components/src/components/postalcodefield/postalcodefield.ts
@@ -1,5 +1,6 @@
 import { PluginObject } from 'vue';
 import Component from 'vue-class-component';
+import { Prop } from 'vue-property-decorator';
 import { InputLabel } from '../../mixins/input-label/input-label';
 import { InputManagement } from '../../mixins/input-management/input-management';
 import { InputState } from '../../mixins/input-state/input-state';
@@ -12,6 +13,13 @@ import { InputMaskOptions } from '../input-mask/input-mask';
 import MaskedfieldPlugin from '../maskedfield/maskedfield';
 import WithRender from './postalcodefield.html';
 
+export enum MPostalCodeFormat {
+    Canada = 'canada',
+    France = 'france',
+    Other = 'other',
+    UnitedStates = 'united-states'
+}
+
 @WithRender
 @Component({
     mixins: [
@@ -23,13 +31,41 @@ import WithRender from './postalcodefield.html';
 })
 export class MPostalcodefield extends ModulVue {
 
+    @Prop({ default: MPostalCodeFormat.Canada })
+    public postalCodeFormat: MPostalCodeFormat;
+
     protected id: string = `mPostalcodefield-${uuid.generate()}`;
 
     get maskOptions(): InputMaskOptions {
-        return {
-            blocks: [3, 3],
-            uppercase: true
-        };
+        switch (this.postalCodeFormat) {
+            case MPostalCodeFormat.Canada:
+                return {
+                    blocks: [3, 3],
+                    uppercase: true
+                };
+            case MPostalCodeFormat.France:
+                return {
+                    blocks: [2, 3],
+                    uppercase: true
+                };
+            case MPostalCodeFormat.UnitedStates:
+                return {
+                    blocks: [5],
+                    uppercase: true
+                };
+            case MPostalCodeFormat.Other:
+                // Infinite value to display normaly with no space the default values if no blocks is specified!
+                return {
+                    blocks: [1e+23],
+                    uppercase: true
+                };
+            default:
+                // Infinite value to display normaly with no space the default values if no blocks is specified!
+                return {
+                    blocks: [1e+23],
+                    uppercase: true
+                };
+        }
     }
 
     get bindData(): any {

--- a/packages/modul-components/src/components/postalcodefield/postalcodefield.ts
+++ b/packages/modul-components/src/components/postalcodefield/postalcodefield.ts
@@ -55,7 +55,7 @@ export class MPostalcodefield extends ModulVue {
                 };
             case MPostalCodeFormat.Other:
             default:
-                // Infinite value to display normaly with no space the default values if no blocks is specified!
+                // Infinite value to display normaly with no space the default values if value is orther or invalid!
                 return {
                     blocks: [1e+23],
                     uppercase: true

--- a/packages/modul-components/src/components/postalcodefield/postalcodefield.ts
+++ b/packages/modul-components/src/components/postalcodefield/postalcodefield.ts
@@ -1,0 +1,48 @@
+import { PluginObject } from 'vue';
+import Component from 'vue-class-component';
+import { InputLabel } from '../../mixins/input-label/input-label';
+import { InputManagement } from '../../mixins/input-management/input-management';
+import { InputState } from '../../mixins/input-state/input-state';
+import { InputWidth } from '../../mixins/input-width/input-width';
+import L10nPlugin from '../../utils/l10n/l10n';
+import uuid from '../../utils/uuid/uuid';
+import { ModulVue } from '../../utils/vue/vue';
+import { POSTALCODEFIELD_NAME } from '../component-names';
+import { InputMaskOptions } from '../input-mask/input-mask';
+import MaskedfieldPlugin from '../maskedfield/maskedfield';
+import WithRender from './postalcodefield.html';
+
+@WithRender
+@Component({
+    mixins: [
+        InputState,
+        InputWidth,
+        InputLabel,
+        InputManagement
+    ]
+})
+export class MPostalcodefield extends ModulVue {
+
+    protected id: string = `mPostalcodefield-${uuid.generate()}`;
+
+    get maskOptions(): InputMaskOptions {
+        return {
+            blocks: [3, 3],
+            uppercase: true
+        };
+    }
+
+    get bindData(): any {
+        return Object.assign({}, this.$props || {}, this.$attrs || {});
+    }
+}
+
+const PostalcodefieldPlugin: PluginObject<any> = {
+    install(v): void {
+        v.use(L10nPlugin);
+        v.use(MaskedfieldPlugin);
+        v.component(POSTALCODEFIELD_NAME, MPostalcodefield);
+    }
+};
+
+export default PostalcodefieldPlugin;

--- a/src/storybook/src/modul-components/components/postalcodefield/__snapshots__/postalcodefield.stories.ts.snap
+++ b/src/storybook/src/modul-components/components/postalcodefield/__snapshots__/postalcodefield.stories.ts.snap
@@ -1,0 +1,394 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots modul-components|m-postalcodefield Default Story 1`] = `
+<div
+  class="m-maskedlfield m-postalcodefield"
+  id="mPostalcodefield-fakeId"
+  style="width: 100%; max-width: 288px;"
+>
+  <div
+    class="m-input-style m-maskedfield__input-style m--is-tag-default"
+    style="margin-top: 10px;"
+  >
+    <div
+      class="m-input-style__main"
+    >
+      <div
+        class="m-input-style__body"
+      >
+        <span
+          class="m-input-style__label"
+          style="z-index: -1;"
+        >
+          <span
+            class="m-input-style__text"
+          />
+        </span>
+         
+        <div
+          class="m-input-style__input"
+        >
+          <div
+            class="m-input-style__prefix"
+          />
+           
+          <div
+            class="m-input-style__content"
+          >
+             
+            <input
+              id="mMaskedfield-fakeId"
+            />
+              
+            <!---->
+             
+            <!---->
+          </div>
+           
+          <div
+            class="m-input-style__suffix"
+          >
+             
+            <!---->
+          </div>
+        </div>
+      </div>
+       
+      <!---->
+    </div>
+  </div>
+   
+  <div
+    class="m-maskedfield__validation"
+  >
+    <div
+      class="m-validation-message m-maskedfield__validation-message"
+    >
+      <!---->
+       
+      <!---->
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots modul-components|m-postalcodefield With Label And Error 1`] = `
+<div
+  class="m-maskedlfield m-postalcodefield m--has-error m--has-label m--has-validation-message"
+  id="mPostalcodefield-fakeId"
+  style="width: 100%; max-width: 288px;"
+>
+  <div
+    class="m-input-style m-maskedfield__input-style m--is-label-up m--has-error m--has-label m--has-value m--is-tag-default"
+    style="margin-top: 10px;"
+  >
+    <div
+      class="m-input-style__main"
+    >
+      <div
+        class="m-input-style__body"
+      >
+        <label
+          class="m-input-style__label"
+          for="mMaskedfield-fakeId"
+          style="margin-right: 0px;"
+        >
+          <span
+            class="m-input-style__text"
+          >
+            <span>
+              Postal code
+            </span>
+             
+            <!---->
+          </span>
+        </label>
+         
+        <div
+          class="m-input-style__input"
+        >
+          <!---->
+           
+          <div
+            class="m-input-style__content"
+          >
+             
+            <input
+              id="mMaskedfield-fakeId"
+            />
+              
+            <!---->
+             
+            <!---->
+          </div>
+           
+          <div
+            class="m-input-style__suffix"
+          >
+             
+            <!---->
+          </div>
+        </div>
+      </div>
+       
+      <!---->
+    </div>
+  </div>
+   
+  <div
+    class="m-maskedfield__validation"
+  >
+    <div
+      class="m-validation-message m-maskedfield__validation-message"
+    >
+      <p
+        class="m-validation-message__error"
+      >
+        <svg
+          class="m-icon m-validation-message__icon"
+          height="1em"
+          width="1em"
+        >
+          <title>
+            Erreur
+          </title>
+           
+          <use
+            aria-hidden="true"
+            class=""
+          />
+        </svg>
+         
+        <span
+          class="m-validation-message__text"
+        >
+          Invalid postal code with a long long long long long message error
+        </span>
+      </p>
+       
+      <!---->
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots modul-components|m-postalcodefield With Label Up And Full Width 1`] = `
+<div
+  class="m-maskedlfield m-postalcodefield m--has-label"
+  id="mPostalcodefield-fakeId"
+  style="width: 100%; max-width: 100%;"
+>
+  <div
+    class="m-input-style m-maskedfield__input-style m--is-label-up m--has-label m--is-tag-default"
+    style="margin-top: 10px;"
+  >
+    <div
+      class="m-input-style__main"
+    >
+      <div
+        class="m-input-style__body"
+      >
+        <label
+          class="m-input-style__label"
+          for="mMaskedfield-fakeId"
+          style="margin-right: 0px;"
+        >
+          <span
+            class="m-input-style__text"
+          >
+            <span>
+              Postal code
+            </span>
+             
+            <!---->
+          </span>
+        </label>
+         
+        <div
+          class="m-input-style__input"
+        >
+          <!---->
+           
+          <div
+            class="m-input-style__content"
+          >
+             
+            <input
+              id="mMaskedfield-fakeId"
+            />
+              
+            <!---->
+             
+            <!---->
+          </div>
+           
+          <div
+            class="m-input-style__suffix"
+          >
+             
+            <!---->
+          </div>
+        </div>
+      </div>
+       
+      <!---->
+    </div>
+  </div>
+   
+  <div
+    class="m-maskedfield__validation"
+  >
+    <div
+      class="m-validation-message m-maskedfield__validation-message"
+    >
+      <!---->
+       
+      <!---->
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots modul-components|m-postalcodefield With Not Postal Code Default Value 1`] = `
+<div
+  class="m-maskedlfield m-postalcodefield"
+  id="mPostalcodefield-fakeId"
+  style="width: 100%; max-width: 288px;"
+>
+  <div
+    class="m-input-style m-maskedfield__input-style m--has-value m--is-tag-default"
+    style="margin-top: 10px;"
+  >
+    <div
+      class="m-input-style__main"
+    >
+      <div
+        class="m-input-style__body"
+      >
+        <span
+          class="m-input-style__label"
+          style="z-index: -1;"
+        >
+          <span
+            class="m-input-style__text"
+          />
+        </span>
+         
+        <div
+          class="m-input-style__input"
+        >
+          <div
+            class="m-input-style__prefix"
+          />
+           
+          <div
+            class="m-input-style__content"
+          >
+             
+            <input
+              id="mMaskedfield-fakeId"
+            />
+              
+            <!---->
+             
+            <!---->
+          </div>
+           
+          <div
+            class="m-input-style__suffix"
+          >
+             
+            <!---->
+          </div>
+        </div>
+      </div>
+       
+      <!---->
+    </div>
+  </div>
+   
+  <div
+    class="m-maskedfield__validation"
+  >
+    <div
+      class="m-validation-message m-maskedfield__validation-message"
+    >
+      <!---->
+       
+      <!---->
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots modul-components|m-postalcodefield With Value 1`] = `
+<div
+  class="m-maskedlfield m-postalcodefield"
+  id="mPostalcodefield-fakeId"
+  style="width: 100%; max-width: 288px;"
+>
+  <div
+    class="m-input-style m-maskedfield__input-style m--has-value m--is-tag-default"
+    style="margin-top: 10px;"
+  >
+    <div
+      class="m-input-style__main"
+    >
+      <div
+        class="m-input-style__body"
+      >
+        <span
+          class="m-input-style__label"
+          style="z-index: -1;"
+        >
+          <span
+            class="m-input-style__text"
+          />
+        </span>
+         
+        <div
+          class="m-input-style__input"
+        >
+          <div
+            class="m-input-style__prefix"
+          />
+           
+          <div
+            class="m-input-style__content"
+          >
+             
+            <input
+              id="mMaskedfield-fakeId"
+            />
+              
+            <!---->
+             
+            <!---->
+          </div>
+           
+          <div
+            class="m-input-style__suffix"
+          >
+             
+            <!---->
+          </div>
+        </div>
+      </div>
+       
+      <!---->
+    </div>
+  </div>
+   
+  <div
+    class="m-maskedfield__validation"
+  >
+    <div
+      class="m-validation-message m-maskedfield__validation-message"
+    >
+      <!---->
+       
+      <!---->
+    </div>
+  </div>
+</div>
+`;

--- a/src/storybook/src/modul-components/components/postalcodefield/__snapshots__/postalcodefield.stories.ts.snap
+++ b/src/storybook/src/modul-components/components/postalcodefield/__snapshots__/postalcodefield.stories.ts.snap
@@ -4,10 +4,230 @@ exports[`Storyshots modul-components|m-postalcodefield Default Story 1`] = `
 <div
   class="m-maskedlfield m-postalcodefield"
   id="mPostalcodefield-fakeId"
+  postalcodeformat="canada"
   style="width: 100%; max-width: 288px;"
 >
   <div
-    class="m-input-style m-maskedfield__input-style m--is-tag-default"
+    class="m-input-style m-maskedfield__input-style m--has-value m--is-tag-default"
+    style="margin-top: 10px;"
+  >
+    <div
+      class="m-input-style__main"
+    >
+      <div
+        class="m-input-style__body"
+      >
+        <span
+          class="m-input-style__label"
+          style="z-index: -1;"
+        >
+          <span
+            class="m-input-style__text"
+          />
+        </span>
+         
+        <div
+          class="m-input-style__input"
+        >
+          <div
+            class="m-input-style__prefix"
+          />
+           
+          <div
+            class="m-input-style__content"
+          >
+             
+            <input
+              id="mMaskedfield-fakeId"
+            />
+              
+            <!---->
+             
+            <!---->
+          </div>
+           
+          <div
+            class="m-input-style__suffix"
+          >
+             
+            <!---->
+          </div>
+        </div>
+      </div>
+       
+      <!---->
+    </div>
+  </div>
+   
+  <div
+    class="m-maskedfield__validation"
+  >
+    <div
+      class="m-validation-message m-maskedfield__validation-message"
+    >
+      <!---->
+       
+      <!---->
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots modul-components|m-postalcodefield France 1`] = `
+<div
+  class="m-maskedlfield m-postalcodefield"
+  id="mPostalcodefield-fakeId"
+  postalcodeformat="france"
+  style="width: 100%; max-width: 288px;"
+>
+  <div
+    class="m-input-style m-maskedfield__input-style m--has-value m--is-tag-default"
+    style="margin-top: 10px;"
+  >
+    <div
+      class="m-input-style__main"
+    >
+      <div
+        class="m-input-style__body"
+      >
+        <span
+          class="m-input-style__label"
+          style="z-index: -1;"
+        >
+          <span
+            class="m-input-style__text"
+          />
+        </span>
+         
+        <div
+          class="m-input-style__input"
+        >
+          <div
+            class="m-input-style__prefix"
+          />
+           
+          <div
+            class="m-input-style__content"
+          >
+             
+            <input
+              id="mMaskedfield-fakeId"
+            />
+              
+            <!---->
+             
+            <!---->
+          </div>
+           
+          <div
+            class="m-input-style__suffix"
+          >
+             
+            <!---->
+          </div>
+        </div>
+      </div>
+       
+      <!---->
+    </div>
+  </div>
+   
+  <div
+    class="m-maskedfield__validation"
+  >
+    <div
+      class="m-validation-message m-maskedfield__validation-message"
+    >
+      <!---->
+       
+      <!---->
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots modul-components|m-postalcodefield Other 1`] = `
+<div
+  class="m-maskedlfield m-postalcodefield"
+  id="mPostalcodefield-fakeId"
+  postalcodeformat="other"
+  style="width: 100%; max-width: 288px;"
+>
+  <div
+    class="m-input-style m-maskedfield__input-style m--has-value m--is-tag-default"
+    style="margin-top: 10px;"
+  >
+    <div
+      class="m-input-style__main"
+    >
+      <div
+        class="m-input-style__body"
+      >
+        <span
+          class="m-input-style__label"
+          style="z-index: -1;"
+        >
+          <span
+            class="m-input-style__text"
+          />
+        </span>
+         
+        <div
+          class="m-input-style__input"
+        >
+          <div
+            class="m-input-style__prefix"
+          />
+           
+          <div
+            class="m-input-style__content"
+          >
+             
+            <input
+              id="mMaskedfield-fakeId"
+            />
+              
+            <!---->
+             
+            <!---->
+          </div>
+           
+          <div
+            class="m-input-style__suffix"
+          >
+             
+            <!---->
+          </div>
+        </div>
+      </div>
+       
+      <!---->
+    </div>
+  </div>
+   
+  <div
+    class="m-maskedfield__validation"
+  >
+    <div
+      class="m-validation-message m-maskedfield__validation-message"
+    >
+      <!---->
+       
+      <!---->
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots modul-components|m-postalcodefield United States 1`] = `
+<div
+  class="m-maskedlfield m-postalcodefield"
+  id="mPostalcodefield-fakeId"
+  postalcodeformat="united-states"
+  style="width: 100%; max-width: 288px;"
+>
+  <div
+    class="m-input-style m-maskedfield__input-style m--has-value m--is-tag-default"
     style="margin-top: 10px;"
   >
     <div
@@ -76,6 +296,7 @@ exports[`Storyshots modul-components|m-postalcodefield With Label And Error 1`] 
 <div
   class="m-maskedlfield m-postalcodefield m--has-error m--has-label m--has-validation-message"
   id="mPostalcodefield-fakeId"
+  postalcodeformat="canada"
   style="width: 100%; max-width: 288px;"
 >
   <div
@@ -176,6 +397,7 @@ exports[`Storyshots modul-components|m-postalcodefield With Label Up And Full Wi
 <div
   class="m-maskedlfield m-postalcodefield m--has-label"
   id="mPostalcodefield-fakeId"
+  postalcodeformat="canada"
   style="width: 100%; max-width: 100%;"
 >
   <div
@@ -253,6 +475,7 @@ exports[`Storyshots modul-components|m-postalcodefield With Not Postal Code Defa
 <div
   class="m-maskedlfield m-postalcodefield"
   id="mPostalcodefield-fakeId"
+  postalcodeformat="canada"
   style="width: 100%; max-width: 288px;"
 >
   <div
@@ -325,6 +548,7 @@ exports[`Storyshots modul-components|m-postalcodefield With Value 1`] = `
 <div
   class="m-maskedlfield m-postalcodefield"
   id="mPostalcodefield-fakeId"
+  postalcodeformat="canada"
   style="width: 100%; max-width: 288px;"
 >
   <div

--- a/src/storybook/src/modul-components/components/postalcodefield/postalcodefield.stories.ts
+++ b/src/storybook/src/modul-components/components/postalcodefield/postalcodefield.stories.ts
@@ -1,0 +1,46 @@
+import { POSTALCODEFIELD_NAME } from '@ulaval/modul-components/dist/components/component-names';
+import { modulComponentsHierarchyRootSeparator } from '../../../utils';
+
+export default {
+    title: `${modulComponentsHierarchyRootSeparator}${POSTALCODEFIELD_NAME}`,
+    parameters: { fileName: __filename }
+};
+
+export const defaultStory = () => ({
+    data: () => ({
+        model: ''
+    }),
+    template: `<${POSTALCODEFIELD_NAME} v-model="model"></${POSTALCODEFIELD_NAME}>`
+});
+
+defaultStory.story = {
+    name: 'Default'
+};
+
+export const withValue = () => ({
+    data: () => ({
+        model: 'G1V0A6'
+    }),
+    template: `<${POSTALCODEFIELD_NAME} v-model="model"></${POSTALCODEFIELD_NAME}>`
+});
+
+export const withNotPostalCodeDefaultValue = () => ({
+    data: () => ({
+        model: 'ad23dgvb3ssdffdd'
+    }),
+    template: `<${POSTALCODEFIELD_NAME} v-model="model"></${POSTALCODEFIELD_NAME}>`
+});
+
+export const withLabelAndError = () => ({
+    data: () => ({
+        model: '123456'
+    }),
+    template: `<${POSTALCODEFIELD_NAME} v-model="model" label="Postal code" :error="true" error-message="Invalid postal code with a long long long long long message error"></${POSTALCODEFIELD_NAME}>`
+});
+
+export const withLabelUpAndFullWidth = () => ({
+    data: () => ({
+        model: ''
+    }),
+    template: `<${POSTALCODEFIELD_NAME} v-model="model" label="Postal code" :label-up="true" max-width="100%"></${POSTALCODEFIELD_NAME}>`
+});

--- a/src/storybook/src/modul-components/components/postalcodefield/postalcodefield.stories.ts
+++ b/src/storybook/src/modul-components/components/postalcodefield/postalcodefield.stories.ts
@@ -1,4 +1,5 @@
 import { POSTALCODEFIELD_NAME } from '@ulaval/modul-components/dist/components/component-names';
+import { MPostalCodeFormat } from '@ulaval/modul-components/dist/components/postalcodefield/postalcodefield';
 import { modulComponentsHierarchyRootSeparator } from '../../../utils';
 
 export default {
@@ -8,7 +9,7 @@ export default {
 
 export const defaultStory = () => ({
     data: () => ({
-        model: ''
+        model: 'asdfa2341234'
     }),
     template: `<${POSTALCODEFIELD_NAME} v-model="model"></${POSTALCODEFIELD_NAME}>`
 });
@@ -22,6 +23,30 @@ export const withValue = () => ({
         model: 'G1V0A6'
     }),
     template: `<${POSTALCODEFIELD_NAME} v-model="model"></${POSTALCODEFIELD_NAME}>`
+});
+
+export const other = () => ({
+    data: () => ({
+        model: 'G1V0A6',
+        postalCodeFormat: MPostalCodeFormat.Other
+    }),
+    template: `<${POSTALCODEFIELD_NAME} v-model="model" :postal-code-format="postalCodeFormat"></${POSTALCODEFIELD_NAME}>`
+});
+
+export const UnitedStates = () => ({
+    data: () => ({
+        model: '10001',
+        postalCodeFormat: MPostalCodeFormat.UnitedStates
+    }),
+    template: `<${POSTALCODEFIELD_NAME} v-model="model" :postal-code-format="postalCodeFormat"></${POSTALCODEFIELD_NAME}>`
+});
+
+export const France = () => ({
+    data: () => ({
+        model: '75012',
+        postalCodeFormat: MPostalCodeFormat.France
+    }),
+    template: `<${POSTALCODEFIELD_NAME} v-model="model" :postal-code-format="postalCodeFormat"></${POSTALCODEFIELD_NAME}>`
 });
 
 export const withNotPostalCodeDefaultValue = () => ({

--- a/src/storybook/src/modul.ts
+++ b/src/storybook/src/modul.ts
@@ -41,6 +41,7 @@ import OverlayPlugin from '@ulaval/modul-components/dist/components/overlay/over
 import PaginationPlguin from '@ulaval/modul-components/dist/components/pagination/pagination';
 import PanelPlugin from '@ulaval/modul-components/dist/components/panel/panel';
 import PopupPlugin from '@ulaval/modul-components/dist/components/popup/popup';
+import PostalcodefieldPlugin from '@ulaval/modul-components/dist/components/postalcodefield/postalcodefield';
 import ProgressPlugin from '@ulaval/modul-components/dist/components/progress/progress';
 import RadioGroupPlugin from '@ulaval/modul-components/dist/components/radio-group/radio-group';
 import SearchfieldPlugin from '@ulaval/modul-components/dist/components/searchfield/searchfield';
@@ -159,6 +160,7 @@ export const ModulPlugin: PluginObject<any> = {
         Vue.use(DecimalfieldPlugin);
         Vue.use(IntegerfieldPlugin);
         Vue.use(MaskedfieldPlugin);
+        Vue.use(PostalcodefieldPlugin);
 
         Vue.use(FormPlugin);
 


### PR DESCRIPTION
<!--
Veuillez consulter les directives de contribution / Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Content can be written in English or in French
-->

## Description
Nouveau composant pour l'affichage des codes postaux canadiens pour le moment

## Types de changements
<!--- Indiquez ici quels types de modifications votre code introduit / Indicated here what types of changes does your code introduce -->
- [ ] Correction de bug (sans `breaking change`)
- [ ] Amélioration (ajout par example une nouvelle propriété, évènement, slot ou méthode à un composant existant sans `breaking change`)
- [X] Nouvelle fonctionalité (nouveau composant, directive, filtre ou service)
- [ ] Breaking change (modification à une fonctionnalités existante qui nécessite une migration *remplir la section release note*)
- [ ] Refactoring/ménage (sans `breaking change`)
- [ ] Documentation/storybook (changement à la documentation ou aux storybooks qui n'affecte aucun package)
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Comment cela peut-il être testé?
<!--- Décrivez comment vous avez testé vos modifications / Please describe how you tested your changes -->
- [ ] Test unitaire (un nouveau test unitaire à été fait)
- [X] Storybook
- [ ] Test manuel / Sandboxes
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Inclure cette section dans les release notes
<!-- Pour chaque breaking changes , inscrire la description du changement et les instructions pour la migration -->

## Liens internes
Lien jira : https://jira.dti.ulaval.ca/browse/ENA2-10299
Environnement déployé : http://feature-ena2-10299-creer-composant-m-postalcodefield-ul-modul-dv01.pca.svc.ulaval.ca 

<!--  Merci d'avoir contribué! / Thanks for contributing! -->
