### PR TITLE
[m-phonefield] cleanup internal sprite

### DIFF
--- a/packages/modul-components/src/components/phonefield/phonefield.ts
+++ b/packages/modul-components/src/components/phonefield/phonefield.ts
@@ -96,6 +96,9 @@ export class MPhonefield extends ModulVue {
     i18nCountryLabel: string = this.$i18n.translate('m-phonefield:country-label');
     i18nExample: string = this.$i18n.translate('m-phonefield:example');
 
+
+    internalSpriteId: string;
+
     beforeMount(): void {
         // sprites-flags.svg is a very big file, this is why sprites should only be added to the DOM before this component is mounted.
         const sprites: string = require('../../assets/icons/sprites-flags.svg');
@@ -105,9 +108,13 @@ export class MPhonefield extends ModulVue {
                 svg.addExternalSprites(sprites, 'mflag');
             }
         } else {
-            if (!document.getElementById('mflag-svg__flag-ae')) {
-                svg.addInternalSprites(sprites);
-            }
+            this.internalSpriteId = svg.addInternalSprites(sprites);
+        }
+    }
+
+    destroyed(): void {
+        if (this.internalSpriteId) {
+            this.$svg.removeInternalSprite(this.internalSpriteId);
         }
     }
 

--- a/packages/modul-components/src/utils/component/component-mixin.ts
+++ b/packages/modul-components/src/utils/component/component-mixin.ts
@@ -20,6 +20,9 @@ type SpritesComponentOptions = { internalSprites: string | string[] };
 @Component
 export class MComponentMixin extends Vue {
 
+
+    componentMixinsInternalSpriteIds: string[];
+
     beforeCreate(): void {
         if (this.$options.modul) {
 
@@ -51,19 +54,29 @@ export class MComponentMixin extends Vue {
                 const svgComponentOptions: SpritesComponentOptions = this.$options.modul.sprites;
 
                 if (svgComponentOptions.internalSprites) {
+                    this.componentMixinsInternalSpriteIds = [];
                     if (Array.isArray(svgComponentOptions.internalSprites)) {
                         svgComponentOptions.internalSprites.forEach(sprite => {
-                            this.$svg.addInternalSprites(sprite);
+                            this.componentMixinsInternalSpriteIds.push(this.$svg.addInternalSprites(sprite));
                         });
                     } else {
-                        this.$svg.addInternalSprites(svgComponentOptions.internalSprites);
+
+                        this.componentMixinsInternalSpriteIds.push(this.$svg.addInternalSprites(svgComponentOptions.internalSprites));
                     }
                 } else {
                     throw new Error(`You must provide an internalSprites option`);
                 }
             }
         }
+    }
 
+    destroyed(): void {
+
+        if (this.componentMixinsInternalSpriteIds && this.componentMixinsInternalSpriteIds.length > 0) {
+            this.componentMixinsInternalSpriteIds.forEach(componentMixinsInternalSpriteId => {
+                this.$svg.removeInternalSprite(componentMixinsInternalSpriteId);
+            });
+        }
     }
 }
 

--- a/packages/modul-components/src/utils/svg/sprites.ts
+++ b/packages/modul-components/src/utils/svg/sprites.ts
@@ -28,6 +28,14 @@ export class SpritesService {
         return id;
     }
 
+    public removeInternalSprite(id: string): void {
+        if (document.getElementById(id) !== null) {
+            document.getElementById(id)!.remove();
+        } else {
+            Vue.prototype.$log.warn(`unable to remove internal sprite with id=${id}`);
+        }
+    }
+
     public addExternalSprites(sprites: string, externalSpriteIdPrefix: string): void {
         if (this.isInExternalSprites(externalSpriteIdPrefix)) {
             Vue.prototype.$log.warn('"' + externalSpriteIdPrefix + '" already exists in the externalSpriteIdPrefixes. You are overwriting a sprites collection.');


### PR DESCRIPTION
<!--
Veuillez consulter les directives de contribution / Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Content can be written in English or in French
-->

## Description
<!-- Décrivez brièvement les changements introduits par ce PR / Provide a small description of the changes introduced by this PR -->
Ajout d'une méthode get remove internal sprite au service $svg qui permet d'enlever le sprite du DOM lorsqu'on utilise des sprites locale (comme dans le cas du m-phonefield ou avec l'option sprites du component-mixins)


## Types de changements
<!--- Indiquez ici quels types de modifications votre code introduit / Indicated here what types of changes does your code introduce -->
- [ ] Correction de bug (sans `breaking change`)
- [ ] Amélioration (ajout par example une nouvelle propriété, évènement, slot ou méthode à un composant existant sans `breaking change`)
- [ ] Nouvelle fonctionalité (nouveau composant, directive, filtre ou service)
- [ ] Breaking change (modification à une fonctionnalités existante qui nécessite une migration *remplir la section release note*)
- [x] Refactoring/ménage (sans `breaking change`)
- [ ] Documentation/storybook (changement à la documentation ou aux storybooks qui n'affecte aucun package)
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Comment cela peut-il être testé?
<!--- Décrivez comment vous avez testé vos modifications / Please describe how you tested your changes -->
- [ ] Test unitaire (un nouveau test unitaire à été fait)
- [x] Storybook
- [ ] Test manuel / Sandboxes
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Inclure cette section dans les release notes
<!-- Pour chaque breaking changes , inscrire la description du changement et les instructions pour la migration -->

## Liens internes
<!-- Si vous êtes un contributeur interne, ajouter les liens vers vos billets Jira. ou déploiement dans openshift -->

<!--  Merci d'avoir contribué! / Thanks for contributing! -->
