### PR TITLE
m-phonefield: Fixer la largeur du dropdown du drapeau

### DIFF
--- a/packages/modul-components/src/components/phonefield/phonefield.scss
+++ b/packages/modul-components/src/components/phonefield/phonefield.scss
@@ -21,8 +21,10 @@
     }
 
     &__wrapper {
+        $m-phonefiled--width-flag-dropdown: 88px;
+
         display: grid;
-        grid-template-columns: auto auto;
+        grid-template-columns: #{$m-phonefiled--width-flag-dropdown} auto;
     }
 
     &__country {


### PR DESCRIPTION
## Description
Fixer la largeur du dropdown du drapeau.

**Problème dans le projet _Dossier individu_**
Il y a espace entre le dropdown de drapeau et le champ de numéro de téléphone.
<img width="332" alt="m-phonefield_probleme-espacement" src="https://user-images.githubusercontent.com/29067208/78932347-4ffd8b00-7a75-11ea-98ad-708e42920cb5.png">

## Types de changements
<!--- Indiquez ici quels types de modifications votre code introduit / Indicated here what types of changes does your code introduce -->
- [x] Correction de bug (sans `breaking change`)
- [ ] Amélioration (ajout par example une nouvelle propriété, évènement, slot ou méthode à un composant existant sans `breaking change`)
- [ ] Nouvelle fonctionalité (nouveau composant, directive, filtre ou service)
- [ ] Breaking change (modification à une fonctionnalités existante qui nécessite une migration *remplir la section release note*)
- [ ] Refactoring/ménage (sans `breaking change`)
- [ ] Documentation/storybook (changement à la documentation ou aux storybooks qui n'affecte aucun package)
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Comment cela peut-il être testé?
<!--- Décrivez comment vous avez testé vos modifications / Please describe how you tested your changes -->
- [ ] Test unitaire (un nouveau test unitaire à été fait)
- [ ] Storybook
- [ ] Test manuel / Sandboxes
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Inclure cette section dans les release notes
<!-- Pour chaque breaking changes , inscrire la description du changement et les instructions pour la migration -->

## Liens internes
<!-- Si vous êtes un contributeur interne, ajouter les liens vers vos billets Jira. ou déploiement dans openshift -->

<!--  Merci d'avoir contribué! / Thanks for contributing! -->
