### PR TITLE
m-table: ajuster la largeur du placeholder du tableau

### DIFF
--- a/packages/modul-components/src/components/table/__snapshots__/table.spec.ts.snap
+++ b/packages/modul-components/src/components/table/__snapshots__/table.spec.ts.snap
@@ -187,8 +187,8 @@ exports[`MTable Given an empty table When a custom slot is given Then should ren
   </thead>
   <tbody>
     <tr class="m-table__placeholder">
-      <td class="m-table__placeholder-container" style="position:absolute;width:100%;">
-        <div class="m-table__placeholder-message">
+      <td colspan="100%" class="m-table__placeholder-container" style="position:absolute;">
+        <div class="m-table__placeholder-message" style="width:100%;">
           <p>EMPTY</p>
         </div>
       </td>
@@ -216,9 +216,9 @@ exports[`MTable Given an empty table When loading Then should render correctly 1
   </thead>
   <tbody>
     <tr class="m-table__placeholder">
-      <td class="m-table__placeholder-container" style="position:absolute;width:100%;">
+      <td colspan="100%" class="m-table__placeholder-container" style="position:absolute;">
         <m-progress indeterminate="indeterminate"></m-progress>
-        <div class="m-table__placeholder-message">
+        <div class="m-table__placeholder-message" style="width:100%;">
           <p>m-table:loading</p>
           <p class="m-table__placeholder-precision">m-table:please-wait</p>
         </div>
@@ -247,8 +247,8 @@ exports[`MTable Given an empty table When we use the default template Then shoul
   </thead>
   <tbody>
     <tr class="m-table__placeholder">
-      <td class="m-table__placeholder-container" style="position:absolute;width:100%;">
-        <div class="m-table__placeholder-message">
+      <td colspan="100%" class="m-table__placeholder-container" style="position:absolute;">
+        <div class="m-table__placeholder-message" style="width:100%;">
           <p>m-table:no-data</p>
         </div>
       </td>

--- a/packages/modul-components/src/components/table/table.html
+++ b/packages/modul-components/src/components/table/table.html
@@ -50,11 +50,13 @@
             <tr class="m-table__placeholder"
                 v-if="isEmpty || loading">
                 <td class="m-table__placeholder-container"
-                    :style="{ position: placeholderPositionType, width: widthPlaceholder }">
+                    :style="{ position: placeholderPositionType }"
+                    colspan="100%">
                     <m-progress v-if="loading"
                                 :indeterminate="true"
                                 :border-radius="false" />
-                    <div class="m-table__placeholder-message">
+                    <div class="m-table__placeholder-message"
+                         :style="{ width: widthPlaceholder }">
                         <slot name="empty"
                               v-if="isEmpty">
                             <p>{{ i18nEmptyTable }}</p>

--- a/packages/modul-components/src/components/table/table.scss
+++ b/packages/modul-components/src/components/table/table.scss
@@ -242,8 +242,6 @@ $m-sortable-icon-size: 14px;
         position: sticky;
         right: 0;
         left: 0;
-        display: flex;
-        flex-direction: column;
         background-color: $m-color--grey-lightest;
 
         &.m-table__placeholder-container {

--- a/src/storybook/src/modul-components/components/table/__snapshots__/table.stories.ts.snap
+++ b/src/storybook/src/modul-components/components/table/__snapshots__/table.stories.ts.snap
@@ -1376,12 +1376,14 @@ exports[`Storyshots modul-components|m-table Empty table - custom slot 1`] = `
     >
       <td
         class="m-table__placeholder-container"
-        style="position: absolute; width: 100%;"
+        colspan="100%"
+        style="position: absolute;"
       >
         <!---->
          
         <div
           class="m-table__placeholder-message"
+          style="width: 100%;"
         >
           <td
             class="m-table-sandbox__empty__cell"
@@ -1449,12 +1451,14 @@ exports[`Storyshots modul-components|m-table Empty table - default slot 1`] = `
     >
       <td
         class="m-table__placeholder-container"
-        style="position: absolute; width: 100%;"
+        colspan="100%"
+        style="position: absolute;"
       >
         <!---->
          
         <div
           class="m-table__placeholder-message"
+          style="width: 100%;"
         >
           <p>
             Aucune donnée à afficher
@@ -1517,7 +1521,8 @@ exports[`Storyshots modul-components|m-table Loading 1`] = `
     >
       <td
         class="m-table__placeholder-container"
-        style="position: absolute; width: 100%;"
+        colspan="100%"
+        style="position: absolute;"
       >
         <div
           class="m-progress m--is-indeterminate m--is-in-progress"
@@ -1533,6 +1538,7 @@ exports[`Storyshots modul-components|m-table Loading 1`] = `
          
         <div
           class="m-table__placeholder-message"
+          style="width: 100%;"
         >
           <!---->
            
@@ -3310,12 +3316,14 @@ exports[`Storyshots modul-components|m-table Width placeholer 1`] = `
       >
         <td
           class="m-table__placeholder-container"
-          style="position: sticky; width: 500px;"
+          colspan="100%"
+          style="position: sticky;"
         >
           <!---->
            
           <div
             class="m-table__placeholder-message"
+            style="width: 500px;"
           >
             <p>
               Aucune donnée à afficher


### PR DESCRIPTION
## Description
**Ajuster la largeur du placeholder du tableau.**
- Ajouter un `colspan="100%"` sur le `<td>` du placeholder du tableau.
- Voir la story : http://localhost:8082/?path=/story/modul-components-m-table--width-placeholer

## Types de changements
<!--- Indiquez ici quels types de modifications votre code introduit / Indicated here what types of changes does your code introduce -->
- [x] Correction de bug (sans `breaking change`)
- [ ] Amélioration (ajout par example une nouvelle propriété, évènement, slot ou méthode à un composant existant sans `breaking change`)
- [ ] Nouvelle fonctionalité (nouveau composant, directive, filtre ou service)
- [ ] Breaking change (modification à une fonctionnalités existante qui nécessite une migration *remplir la section release note*)
- [ ] Refactoring/ménage (sans `breaking change`)
- [ ] Documentation/storybook (changement à la documentation ou aux storybooks qui n'affecte aucun package)
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Comment cela peut-il être testé?
<!--- Décrivez comment vous avez testé vos modifications / Please describe how you tested your changes -->
- [ ] Test unitaire (un nouveau test unitaire à été fait)
- [x] Storybook
- [ ] Test manuel / Sandboxes
- [ ] Autre
http://localhost:8082/?path=/story/modul-components-m-table--width-placeholer
<!-- si vous avez sélectionner autre, préciser ici -->

## Inclure cette section dans les release notes
<!-- Pour chaque breaking changes , inscrire la description du changement et les instructions pour la migration -->

## Liens internes
<!-- Si vous êtes un contributeur interne, ajouter les liens vers vos billets Jira. ou déploiement dans openshift -->

<!--  Merci d'avoir contribué! / Thanks for contributing! -->
