### PR TITLE
[m-popup] Impossible de désactiver le du close-on-click-outside sur le popper a partir de la props close on backdrop

### DIFF
--- a/packages/modul-components/src/components/popup/popup.html
+++ b/packages/modul-components/src/components/popup/popup.html
@@ -27,6 +27,7 @@
               :preload="preload"
               :width="width"
               :background="background"
+              :close-on-click-outside="closeOnBackdrop"
               @open="onOpen"
               @close="onClose"
               @portal-mounted="onPortalMounted"

--- a/src/storybook/src/modul-components/components/popup/__snapshots__/popup.stories.ts.snap
+++ b/src/storybook/src/modul-components/components/popup/__snapshots__/popup.stories.ts.snap
@@ -1,0 +1,75 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots modul-components|m-popup Close On Backdrop Disabled 1`] = `
+<div
+  class="m-popup m--is-inline"
+>
+  <div
+    class="m-popper"
+  >
+    <div>
+      <button
+        class="m-button m--is-skin-primary"
+        type="button"
+      >
+        <!---->
+         
+        <!---->
+         
+        <span
+          class="m-button__text"
+        >
+          Open popper 
+          <!---->
+        </span>
+         
+        <!---->
+         
+        <!---->
+      </button>
+    </div>
+     
+    <!---->
+  </div>
+   
+  <!---->
+</div>
+`;
+
+exports[`Storyshots modul-components|m-popup default 1`] = `
+<div>
+  <div
+    class="m-popup m--is-inline"
+  >
+    <div
+      class="m-popper"
+    >
+      <div>
+        <button
+          class="m-button m--is-skin-primary"
+          type="button"
+        >
+          <!---->
+           
+          <!---->
+           
+          <span
+            class="m-button__text"
+          >
+            Open popper 
+            <!---->
+          </span>
+           
+          <!---->
+           
+          <!---->
+        </button>
+      </div>
+       
+      <!---->
+    </div>
+     
+    <!---->
+  </div>
+</div>
+`;

--- a/src/storybook/src/modul-components/components/popup/popup.stories.ts
+++ b/src/storybook/src/modul-components/components/popup/popup.stories.ts
@@ -1,0 +1,57 @@
+import { actions } from '@storybook/addon-actions';
+import { boolean, text } from '@storybook/addon-knobs';
+import { POPUP_NAME } from '@ulaval/modul-components/dist/components/component-names';
+import { modulComponentsHierarchyRootSeparator } from '../../../utils';
+
+export default {
+    title: `${modulComponentsHierarchyRootSeparator}${POPUP_NAME}`,
+    parameters: { fileName: __filename }
+};
+
+export const defaultStory = () => ({
+    props: {
+        closeOnBackdrop: {
+            default: boolean('Toggle closeOnBackdrop', true)
+        },
+        width: {
+            default: text('Width', 'auto')
+        },
+        shadow: {
+            default: boolean('Toggle shadow', true)
+        },
+        padding: {
+            default: boolean('Toggle padding', true)
+        },
+        paddingHeader: {
+            default: boolean('Toggle paddingHeader', true)
+        },
+        paddingBody: {
+            default: boolean('Toggle paddingBody', true)
+        },
+        paddingFooter: {
+            default: boolean('Toggle paddingFooter', true)
+        },
+        background: {
+            default: boolean('Toggle background', true)
+        }
+    },
+    methods: actions(
+        'open',
+        'close',
+        'portalMounted',
+        'portalAfterOpen'
+    ),
+    template: `<div>
+                <m-popup :close-on-backdrop="closeOnBackdrop" :width="width" :shadow="shadow" :padding="padding" :padding-header="paddingHeader" :padding-body="paddingBody" :padding-footer="paddingFooter" :background="background" @open="open" @close="close" @portal-mounted="portalMounted" @portal-after-open="portalAfterOpen">
+                    <m-button slot="trigger">Open popper</m-button>
+                    <p slot="header">Header</p>
+                    <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
+                    <p slot="footer">Footer</p>
+                </m-popup>
+            </div>`
+});
+defaultStory.story = {
+    name: 'default'
+};
+
+export const closeOnBackdropDisabled = () => '<m-popup :close-on-backdrop="false"><m-button slot="trigger">Open popper</m-button><p>Cannot close popup by clicking outside</p></m-popup>';


### PR DESCRIPTION
## Description
closeOnBackdrop seulement sur la sidebar. Sébastien Turcotte en a rajouté un autre sur le popper aussi.

## Types de changements
- [x] Correction de bug (sans `breaking change`)
- [ ] Amélioration (ajout par example une nouvelle propriété, évènement, slot ou méthode à un composant existant sans `breaking change`)
- [ ] Nouvelle fonctionalité (nouveau composant, directive, filtre ou service)
- [ ] Breaking change (modification à une fonctionnalités existante qui nécessite une migration *remplir la section release note*)
- [ ] Refactoring/ménage (sans `breaking change`)
- [ ] Documentation/storybook (changement à la documentation ou aux storybooks qui n'affecte aucun package)
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Comment cela peut-il être testé?
- [ ] Test unitaire (un nouveau test unitaire à été fait)
- [ ] Storybook
- [x] Test manuel / Sandboxes
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Inclure cette section dans les release notes

## Liens internes
N/A (initiative personnelle sans billet Jira)
