### PR TITLE
[m-spinner] Ajuster l'espace entre les texte du spinner et améliorer sa réactivité en mode processing

### DIFF
--- a/packages/modul-components/src/components/spinner/spinner.html
+++ b/packages/modul-components/src/components/spinner/spinner.html
@@ -1,24 +1,35 @@
-<transition :appear="true" :css="false" @enter="onEnter()" @leave="onLeave()">
+<transition :appear="true"
+            :css="false"
+            @enter="openProcessingPortal()"
+            @leave="removeBackdrop()">
     <div class="m-spinner">
-        <portal :target-el="spinnerElement" v-if="initialized">
-            <div ref="spinnerWrap" class="m-spinner__wrap" :class="{'m--is-processing': processing,
-                 'm--is-dark': skin === 'dark',
-                 'm--is-light': skin === 'light',
-                 'm--is-lighter': skin === 'lighter'}">
-                <div aria-hidden="true" class="m-spinner__icon" :class="{ 'm--is-small' : size === 'small'}"></div>
-                <h2 class="m-spinner__title" v-if="hasTitle">
-                    <template v-if="hasTitleMessage">{{ titleMessage }}</template>
-                    <template v-else>
-                        <m-i18n v-if="processing" k="m-spinner:processing"></m-i18n>
-                        <m-i18n v-if="!processing" k="m-spinner:loading"></m-i18n>
-                    </template>
+        <portal :target-el="spinnerElement"
+                v-if="initialized">
+            <div ref="spinnerWrap"
+                 class="m-spinner__wrap"
+                 :class="{
+                    'm--is-processing': processing,
+                    'm--is-dark': skin === 'dark',
+                    'm--is-light': skin === 'light',
+                    'm--is-lighter': skin === 'lighter'
+            }">
+                <div aria-hidden="true"
+                     class="m-spinner__icon"
+                     :class="{ 'm--is-small' : size === 'small'}"></div>
+                <h2 class="m-spinner__title"
+                    v-if="titleMessage || (title && processing) || title">
+                    <template v-if="titleMessage">{{ titleMessage }}</template>
+                    <template v-else-if="title && processing">{{'m-spinner:processing' | f-m-i18n }}</template>
+                    <template v-else-if="title">{{'m-spinner:loading' | f-m-i18n }}</template>
                 </h2>
-                <p class="m-spinner__description" v-if="hasDescription">
-                    <template v-if="hasDescriptionMessage">{{ descriptionMessage }}</template>
-                    <m-i18n v-else k="m-spinner:description"></m-i18n>
+                <p class="m-spinner__description"
+                   v-if="description || descriptionMessage">
+                    <template v-if="descriptionMessage">{{ descriptionMessage }}</template>
+                    <template v-else>{{ 'm-spinner:description' | f-m-i18n }}</template>
                 </p>
             </div>
         </portal>
-        <div ref="spinnerContainer" v-if="!processing"></div>
+        <div ref="spinnerContainer"
+             v-if="!processing"></div>
     </div>
 </transition>

--- a/packages/modul-components/src/components/spinner/spinner.html
+++ b/packages/modul-components/src/components/spinner/spinner.html
@@ -11,8 +11,7 @@
                     'm--is-processing': processing,
                     'm--is-dark': skin === 'dark',
                     'm--is-light': skin === 'light',
-                    'm--is-lighter': skin === 'lighter'
-            }">
+                    'm--is-lighter': skin === 'lighter' }">
                 <div aria-hidden="true"
                      class="m-spinner__icon"
                      :class="{ 'm--is-small' : size === 'small'}"></div>

--- a/packages/modul-components/src/components/spinner/spinner.scss
+++ b/packages/modul-components/src/components/spinner/spinner.scss
@@ -60,14 +60,18 @@ $m-loading-speed: 0.7s;
     }
 
     &__title {
-        margin: $m-margin 0 $m-margin--xs 0;
+        margin: 0;
         font-size: $m-font-size--l;
         font-weight: $m-font-weight--semi-bold;
         white-space: pre-line;
+
+        + .m-spinner__description {
+            margin-top: $m-spacing--xs;
+        }
     }
 
     &__description {
-        margin-top: 0;
+        margin: 0;
         font-size: $m-font-size--s;
     }
 
@@ -85,6 +89,11 @@ $m-loading-speed: 0.7s;
             width: 16px;
             height: 16px;
             border-width: $m-border-width;
+        }
+
+        + .m-spinner__description,
+        + .m-spinner__title {
+            margin-top: $m-spacing;
         }
     }
 }

--- a/packages/modul-components/src/components/spinner/spinner.ts
+++ b/packages/modul-components/src/components/spinner/spinner.ts
@@ -75,7 +75,6 @@ export class MSpinner extends ModulVue {
 
     @Watch('processing')
     private onProcessingChange(value: boolean): void {
-        this.$log.warn(`<${SPINNER_NAME}>: ${PROCESSING_WARN}`);
         if (value) {
             this.openProcessingPortal();
         } else {
@@ -106,7 +105,7 @@ export class MSpinner extends ModulVue {
             this.portalTargetEl = undefined;
         }
 
-        let el: HTMLElement = document.getElementById(this.spinnerId) as HTMLElement;
+        const el: HTMLElement = document.getElementById(this.spinnerId) as HTMLElement;
         if (el) {
             document.body.removeChild(el);
         }

--- a/packages/modul-components/src/components/spinner/spinner.ts
+++ b/packages/modul-components/src/components/spinner/spinner.ts
@@ -8,8 +8,6 @@ import { SPINNER_NAME } from '../component-names';
 import I18nPlugin from '../i18n/i18n';
 import WithRender from './spinner.html?style=./spinner.scss';
 
-
-
 export enum MSpinnerStyle {
     Dark = 'dark',
     Regular = 'regular',
@@ -65,7 +63,6 @@ export class MSpinner extends ModulVue {
     private portalTargetEl: HTMLElement | undefined = {} as HTMLElement; // initialized to be responsive
 
     private initialized: boolean = false; // seems to be necessary since $refs are not responsive
-    private visible: boolean = false;
     private stackId: string;
 
     protected created(): void {
@@ -73,27 +70,24 @@ export class MSpinner extends ModulVue {
     }
 
     protected beforeDestroy(): void {
-        if (this.processing) {
-            let el: HTMLElement = document.getElementById(this.spinnerId) as HTMLElement;
-            if (el) {
-                document.body.removeChild(el);
-            }
-        }
+        this.removeBackdrop();
     }
 
     @Watch('processing')
     private onProcessingChange(value: boolean): void {
         this.$log.warn(`<${SPINNER_NAME}>: ${PROCESSING_WARN}`);
-        if (!value) {
+        if (value) {
+            this.openProcessingPortal();
+        } else {
             this.removeBackdrop();
         }
     }
 
-    private get spinnerElement(): HTMLElement | undefined {
+    public get spinnerElement(): HTMLElement | undefined {
         return this.processing ? this.portalTargetEl : this.$refs.spinnerContainer as HTMLElement;
     }
 
-    private onEnter(): void {
+    public openProcessingPortal(): void {
         if (!this.portalTargetEl && this.processing) {
             let element: HTMLElement = document.createElement('div');
             element.setAttribute('id', this.spinnerId);
@@ -103,14 +97,6 @@ export class MSpinner extends ModulVue {
             this.portalTargetEl.style.position = 'absolute';
         }
         this.initialized = true;
-        this.visible = true;
-    }
-
-    private onLeave(): void {
-        this.visible = false;
-        if (this.processing) {
-            this.removeBackdrop();
-        }
     }
 
     private removeBackdrop(): void {
@@ -119,22 +105,11 @@ export class MSpinner extends ModulVue {
             this.portalTargetEl.style.position = '';
             this.portalTargetEl = undefined;
         }
-    }
 
-    private get hasTitleMessage(): boolean {
-        return this.titleMessage !== '' && this.titleMessage !== undefined;
-    }
-
-    private get hasDescriptionMessage(): boolean {
-        return this.descriptionMessage !== '' && this.descriptionMessage !== undefined;
-    }
-
-    private get hasTitle(): boolean {
-        return this.title || this.hasTitleMessage;
-    }
-
-    private get hasDescription(): boolean {
-        return this.description || this.hasDescriptionMessage;
+        let el: HTMLElement = document.getElementById(this.spinnerId) as HTMLElement;
+        if (el) {
+            document.body.removeChild(el);
+        }
     }
 }
 

--- a/src/storybook/src/modul-components/components/spinner/__snapshots__/spinner.stories.ts.snap
+++ b/src/storybook/src/modul-components/components/spinner/__snapshots__/spinner.stories.ts.snap
@@ -61,14 +61,12 @@ exports[`Storyshots modul-components|m-spinner title-message 1`] = `
 `;
 
 exports[`Storyshots modul-components|m-spinner/knobs all props 1`] = `
-<div>
-  <div
-    class="m-spinner"
-  >
-    <!---->
-     
-    <div />
-  </div>
+<div
+  class="m-spinner"
+>
+  <!---->
+   
+  <div />
 </div>
 `;
 

--- a/src/storybook/src/modul-components/components/spinner/spinner.stories.ts
+++ b/src/storybook/src/modul-components/components/spinner/spinner.stories.ts
@@ -100,11 +100,15 @@ storiesOf(`${modulComponentsHierarchyRootSeparator}${SPINNER_NAME}/knobs`, modul
                 default: select('size', Object.values(MSpinnerSize), MSpinnerSize.Small)
             }
         },
-        template: `<div>
-                        <m-spinner :description="description" :description-message="descriptionMessage"
-                        :processing="processing" :skin="skin" :size="size" :title="title"
-                        :title-message="titleMessage"></m-spinner>
-                   </div>`
+        template: `<m-spinner
+            :title="title"
+            :title-message="titleMessage"
+            :description="description"
+            :description-message="descriptionMessage"
+            :processing="processing"
+            :skin="skin"
+            :size="size"
+        />`
     }));
 
 


### PR DESCRIPTION
## Description
**Problèmes résolus**
- Lorsque la prop `description` est utilisé sans la prop `text`, l'espacement entre l'icône de spinner et la description est insuffisante.
- Lorsque le composant utile la prop `processing: boolean` et que la valeur de cette prop change, le backdrop n'apparait plus en arrière du spinner.

## Types de changements
<!--- Indiquez ici quels types de modifications votre code introduit / Indicated here what types of changes does your code introduce -->
- [x] Correction de bug (sans `breaking change`)
- [ ] Amélioration (ajout par example une nouvelle propriété, évènement, slot ou méthode à un composant existant sans `breaking change`)
- [ ] Nouvelle fonctionalité (nouveau composant, directive, filtre ou service)
- [ ] Breaking change (modification à une fonctionnalités existante qui nécessite une migration *remplir la section release note*)
- [x] Refactoring/ménage (sans `breaking change`)
- [ ] Documentation/storybook (changement à la documentation ou aux storybooks qui n'affecte aucun package)
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Comment cela peut-il être testé?
<!--- Décrivez comment vous avez testé vos modifications / Please describe how you tested your changes -->
- [ ] Test unitaire (un nouveau test unitaire à été fait)
- [x] Storybook
- [ ] Test manuel / Sandboxes
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->
Tester l'utilisation des knobs dans storybook
http://localhost:8082/?path=/story/modul-components-m-spinner-knobs--all-props

## Inclure cette section dans les release notes
<!-- Pour chaque breaking changes , inscrire la description du changement et les instructions pour la migration -->

## Liens internes
<!-- Si vous êtes un contributeur interne, ajouter les liens vers vos billets Jira. ou déploiement dans openshift -->

<!--  Merci d'avoir contribué! / Thanks for contributing! -->
