### PR TITLE
[m-postalcodefield] Changé la casse des codes de pays

### DIFF
--- a/packages/modul-components/src/components/postalcodefield/postalcodefield.ts
+++ b/packages/modul-components/src/components/postalcodefield/postalcodefield.ts
@@ -36,7 +36,7 @@ export class MPostalcodefield extends ModulVue {
     protected id: string = `mPostalcodefield-${uuid.generate()}`;
 
     get maskOptions(): InputMaskOptions {
-        switch (this.postalCodeFormat) {
+        switch (this.postalCodeFormat.toLowerCase()) {
             case MPostalCodeCountry.CA:
                 return {
                     blocks: [3, 3],

--- a/packages/modul-components/src/components/postalcodefield/postalcodefield.ts
+++ b/packages/modul-components/src/components/postalcodefield/postalcodefield.ts
@@ -13,10 +13,10 @@ import MaskedfieldPlugin from '../maskedfield/maskedfield';
 import WithRender from './postalcodefield.html';
 
 export enum MPostalCodeCountry {
-    CA = 'CA',
-    FR = 'FR',
+    CA = 'ca',
+    FR = 'fr',
     Other = 'other',
-    US = 'US'
+    US = 'us'
 }
 
 @WithRender

--- a/packages/modul-components/src/filters/postal-code/postal-code.ts
+++ b/packages/modul-components/src/filters/postal-code/postal-code.ts
@@ -13,7 +13,7 @@ export class PostalCodeFilter {
      * Other — Example: "11111-1111" (string stays the same)
      */
     static format(text: string, isoCountry: string): string {
-        switch (isoCountry) {
+        switch (isoCountry.toLowerCase()) {
             case MPostalCodeCountry.CA: {
                 return [text.slice(0, 3), text.slice(3, 6)].join(' ');
             }

--- a/packages/modul-components/src/filters/postal-code/postal-code.ts
+++ b/packages/modul-components/src/filters/postal-code/postal-code.ts
@@ -6,13 +6,14 @@ export class PostalCodeFilter {
 
     /**
      * Available formats:
+     * No country code specified: Canadian format by default
      * CA (6 characters) — Example: "X1X 1X1"
      * US (5 or less characters) — Example: "11111" (Only 5 first characters are kept)
      * US (more than 5 characters, up to 9) — Example: "11111-1111" (Only 9 first characters are kept)
      * FR (5 characters) — Example: "11111" (Only 5 first characters are kept)
-     * Other — Example: "11111-1111" (string stays the same)
+     * Other specified — Example: "11111-1111" (string stays the same)
      */
-    static format(text: string, isoCountry: string): string {
+    static format(text: string, isoCountry: string = MPostalCodeCountry.CA): string {
         switch (isoCountry.toLowerCase()) {
             case MPostalCodeCountry.CA: {
                 return [text.slice(0, 3), text.slice(3, 6)].join(' ');

--- a/src/storybook/src/modul-components/components/postalcodefield/__snapshots__/postalcodefield.stories.ts.snap
+++ b/src/storybook/src/modul-components/components/postalcodefield/__snapshots__/postalcodefield.stories.ts.snap
@@ -4,7 +4,7 @@ exports[`Storyshots modul-components|m-postalcodefield Default 1`] = `
 <div
   class="m-maskedlfield m-postalcodefield"
   id="mPostalcodefield-fakeId"
-  postalcodeformat="CA"
+  postalcodeformat="ca"
   style="width: 100%; max-width: 288px;"
 >
   <div
@@ -77,7 +77,7 @@ exports[`Storyshots modul-components|m-postalcodefield France 1`] = `
 <div
   class="m-maskedlfield m-postalcodefield"
   id="mPostalcodefield-fakeId"
-  postalcodeformat="FR"
+  postalcodeformat="fr"
   style="width: 100%; max-width: 288px;"
 >
   <div
@@ -223,7 +223,7 @@ exports[`Storyshots modul-components|m-postalcodefield United States 1`] = `
 <div
   class="m-maskedlfield m-postalcodefield"
   id="mPostalcodefield-fakeId"
-  postalcodeformat="US"
+  postalcodeformat="us"
   style="width: 100%; max-width: 288px;"
 >
   <div
@@ -296,7 +296,7 @@ exports[`Storyshots modul-components|m-postalcodefield With Label And Error 1`] 
 <div
   class="m-maskedlfield m-postalcodefield m--has-error m--has-label m--has-validation-message"
   id="mPostalcodefield-fakeId"
-  postalcodeformat="CA"
+  postalcodeformat="ca"
   style="width: 100%; max-width: 288px;"
 >
   <div
@@ -397,7 +397,7 @@ exports[`Storyshots modul-components|m-postalcodefield With Label Up And Full Wi
 <div
   class="m-maskedlfield m-postalcodefield m--has-label"
   id="mPostalcodefield-fakeId"
-  postalcodeformat="CA"
+  postalcodeformat="ca"
   style="width: 100%; max-width: 100%;"
 >
   <div
@@ -475,7 +475,7 @@ exports[`Storyshots modul-components|m-postalcodefield With Not Postal Code Defa
 <div
   class="m-maskedlfield m-postalcodefield"
   id="mPostalcodefield-fakeId"
-  postalcodeformat="CA"
+  postalcodeformat="ca"
   style="width: 100%; max-width: 288px;"
 >
   <div
@@ -548,7 +548,7 @@ exports[`Storyshots modul-components|m-postalcodefield With Value 1`] = `
 <div
   class="m-maskedlfield m-postalcodefield"
   id="mPostalcodefield-fakeId"
-  postalcodeformat="CA"
+  postalcodeformat="ca"
   style="width: 100%; max-width: 288px;"
 >
   <div

--- a/src/storybook/src/modul-components/filters/postal-code/__snapshots__/postal-code.stories.ts.snap
+++ b/src/storybook/src/modul-components/filters/postal-code/__snapshots__/postal-code.stories.ts.snap
@@ -8,7 +8,7 @@ exports[`Storyshots modul-components|f-m-postal-code Ca 1`] = `
 
 exports[`Storyshots modul-components|f-m-postal-code Default 1`] = `
 <div>
-  9999999
+  999 999
 </div>
 `;
 


### PR DESCRIPTION
## Description
Les valeurs de l'enum de postalcodefield auraient dûs être en majuscules pour être consistents avec les autres codes de pays qu'on retrouve dans Modul (comme dans phonefield, par exemple).  

## Types de changements
<!--- Indiquez ici quels types de modifications votre code introduit / Indicated here what types of changes does your code introduce -->
- [ ] Correction de bug (sans `breaking change`)
- [ ] Amélioration (ajout par example une nouvelle propriété, évènement, slot ou méthode à un composant existant sans `breaking change`)
- [ ] Nouvelle fonctionalité (nouveau composant, directive, filtre ou service)
- [x] Breaking change (modification à une fonctionnalités existante qui nécessite une migration *remplir la section release note*)
- [ ] Refactoring/ménage (sans `breaking change`)
- [ ] Documentation/storybook (changement à la documentation ou aux storybooks qui n'affecte aucun package)
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Comment cela peut-il être testé?
<!--- Décrivez comment vous avez testé vos modifications / Please describe how you tested your changes -->
- [ ] Test unitaire (un nouveau test unitaire à été fait)
- [x] Storybook
- [ ] Test manuel / Sandboxes
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Inclure cette section dans les release notes
À chaque endroit où le filtre postalCodeFilter est utilisé, il faut changer la casse du paramètre isoCountry afin que la valeur soit en minuscule.

Pour le m-postalcodefield, il faut aussi s'assurer que la casse de la prop soit en minuscule. Dans le cas de Brio, ça ne cause pas de problème parce que c'était les valeurs d'enum qui étaient utilisées. La correction apportée dans Modul n'apporte pas de breaking change.

## Liens internes
https://jira.dti.ulaval.ca/browse/ENA2-11208
