### PR TITLE
[m-accordion] Désactiver ouverture de l'accordeon sur un élément avec un attribut tabindex

### DIFF
--- a/packages/modul-components/src/components/accordion/accordion.ts
+++ b/packages/modul-components/src/components/accordion/accordion.ts
@@ -201,7 +201,7 @@ export class MAccordion extends ModulVue implements AccordionGateway {
             return;
         }
 
-        let target: Element | null = (event.target as HTMLElement).closest('[href], [onclick], a, button, input, textarea, radio, ' + COMPONENT_IN_CLOSEST);
+        let target: Element | null = (event.target as HTMLElement).closest('[tabindex], [href], [onclick], a, button, input, textarea, radio, ' + COMPONENT_IN_CLOSEST);
 
         if (!this.propDisabled && !target) {
             const initialState: boolean = this.internalPropOpen;

--- a/packages/modul-components/src/components/accordion/accordion.ts
+++ b/packages/modul-components/src/components/accordion/accordion.ts
@@ -43,7 +43,7 @@ export interface AccordionGroupGateway {
     closeAllAccordions(): any;
 }
 
-const COMPONENT_IN_CLOSEST: string = '.' + BUTTON_GROUP_NAME + ', .' + INPUT_STYLE_NAME + ', .' + CHECKBOX_NAME + ', .' + RADIO_GROUP_NAME + ', .' + RADIO_NAME + ', .' + LINK_NAME + ', .' + INPLACE_EDIT_NAME;
+const COMPONENT_IN_CLOSEST: string = `.${BUTTON_GROUP_NAME}, .${INPUT_STYLE_NAME}, .${CHECKBOX_NAME}, .${RADIO_GROUP_NAME}, .${RADIO_NAME}, .${LINK_NAME}, .${INPLACE_EDIT_NAME}`;
 
 function isAccordionGroup(parent: any): parent is AccordionGroupGateway {
     return parent && 'addAccordion' in parent;
@@ -201,7 +201,7 @@ export class MAccordion extends ModulVue implements AccordionGateway {
             return;
         }
 
-        let target: Element | null = (event.target as HTMLElement).closest('[tabindex], [href], [onclick], a, button, input, textarea, radio, ' + COMPONENT_IN_CLOSEST);
+        let target: Element | null = (event.target as HTMLElement).closest(`[href], [onclick], a, button, input, textarea, radio, ${COMPONENT_IN_CLOSEST}`);
 
         if (!this.propDisabled && !target) {
             const initialState: boolean = this.internalPropOpen;


### PR DESCRIPTION
<!--
Veuillez consulter les directives de contribution / Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Content can be written in English or in French
-->

## Description
Désactiver ouverture de l'accordeon sur un élément avec un attribut tabindex
## Types de changements
<!--- Indiquez ici quels types de modifications votre code introduit / Indicated here what types of changes does your code introduce -->
- [ ] Correction de bug (sans `breaking change`)
- [x] Amélioration (ajout par example une nouvelle propriété, évènement, slot ou méthode à un composant existant sans `breaking change`)
- [ ] Nouvelle fonctionalité (nouveau composant, directive, filtre ou service)
- [ ] Breaking change (modification à une fonctionnalités existante qui nécessite une migration *remplir la section release note*)
- [ ] Refactoring/ménage (sans `breaking change`)
- [ ] Documentation/storybook (changement à la documentation ou aux storybooks qui n'affecte aucun package)
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Comment cela peut-il être testé?
<!--- Décrivez comment vous avez testé vos modifications / Please describe how you tested your changes -->
- [ ] Test unitaire (un nouveau test unitaire à été fait)
- [ ] Storybook
- [ ] Test manuel / Sandboxes
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Inclure cette section dans les release notes
<!-- Pour chaque breaking changes , inscrire la description du changement et les instructions pour la migration -->

## Liens internes
<!-- Si vous êtes un contributeur interne, ajouter les liens vers vos billets Jira. ou déploiement dans openshift -->

<!--  Merci d'avoir contribué! / Thanks for contributing! -->
