### PR TITLE
[m-select] Correction de l'espacement du popup lors d'un message erreur

### DIFF
--- a/packages/modul-components/src/components/multi-select/multi-select.html
+++ b/packages/modul-components/src/components/multi-select/multi-select.html
@@ -15,8 +15,7 @@
         <div class="m-multi-select"
              :class="{ 'm--is-open': open,
                 'm--is-disabled': isDisabled,
-                'm--is-waiting': isWaiting,
-                'm--has-validation-message': hasValidationMessage }"
+                'm--is-waiting': isWaiting }"
              :style="{ width: inputWidth, maxWidth: inputMaxWidth }"
              @focus="onFocus"
              @blur="onBlur"
@@ -115,16 +114,22 @@
                     </m-icon>
                 </div>
             </m-input-style>
-            <m-validation-message class="m-multi-select__validation-message"
-                                  :disabled="isDisabled"
-                                  :waiting="isWaiting"
-                                  :error="hasError"
-                                  :valid="isValid"
-                                  :error-message="errorMessage"
-                                  :valid-message="validMessage"
-                                  :helper-message="helperMessage"></m-validation-message>
         </div>
     </template>
+
+    <template #validation-message>
+        <m-validation-message class="m-multi-select__validation-message"
+                              :class="{ 'm--has-validation-message': hasValidationMessage }"
+                              :disabled="isDisabled"
+                              :waiting="isWaiting"
+                              :error="hasError"
+                              :valid="isValid"
+                              :error-message="errorMessage"
+                              :valid-message="validMessage"
+                              :helper-message="helperMessage"></m-validation-message>
+    </template>
+
+
     <template v-if="linkSelectAll"
               v-slot:popup-header>
         <m-select-item @click="onToggleAll"

--- a/packages/modul-components/src/components/multi-select/multi-select.scss
+++ b/packages/modul-components/src/components/multi-select/multi-select.scss
@@ -1,4 +1,4 @@
-@import 'commons';
+@import "commons";
 
 .m-multi-select {
     display: inline-flex;
@@ -6,12 +6,6 @@
 
     &:focus {
         outline: 0 solid transparent;
-    }
-
-    &.m--has-validation-message {
-        .m-multi-select__validation-message {
-            margin-top: $m-spacing--xs;
-        }
     }
 
     &:not(.m--is-disabled) {
@@ -37,10 +31,14 @@
 
     &__validation-message {
         transition: margin-top $m-transition-duration ease;
+
+        &.m--has-validation-message {
+            margin-top: $m-spacing--xs;
+        }
     }
 
     &__chips {
-        min-height: 24px;  // Magic number
+        min-height: 24px; // Magic number
     }
 
     &__chip {

--- a/packages/modul-components/src/components/select/base-select/base-select.html
+++ b/packages/modul-components/src/components/select/base-select/base-select.html
@@ -13,6 +13,9 @@
               :key-end="onKeydownEnd"
               :key-letter="onKeydownLetter"></slot>
     </div>
+
+    <slot name="validation-message"></slot>
+
     <m-popup ref="popup"
              placement="bottom-start"
              :open.sync="internalOpen"
@@ -67,4 +70,5 @@
 
         </ul>
     </m-popup>
+
 </div>

--- a/packages/modul-components/src/components/select/base-select/base-select.scss
+++ b/packages/modul-components/src/components/select/base-select/base-select.scss
@@ -1,6 +1,9 @@
 @import "commons";
 
 .m-base-select {
+    display: inline-flex;
+    flex-direction: column;
+
     &__list {
         margin: 0;
         padding: 0;

--- a/packages/modul-components/src/components/select/select.html
+++ b/packages/modul-components/src/components/select/select.html
@@ -15,8 +15,7 @@
              :class="{ 'm--is-open': open,
                 'm--is-disabled': isDisabled,
                 'm--is-readonly': isReadonly,
-                'm--is-waiting': isWaiting,
-                'm--has-validation-message': hasValidationMessage }"
+                'm--is-waiting': isWaiting }"
              :style="{ width: width, maxWidth: maxWidth }"
              @focus="onFocus"
              @blur="onBlur"
@@ -85,15 +84,19 @@
                 </template>
 
             </m-input-style>
-            <m-validation-message class="m-select__validation-message"
-                                  :disabled="isDisabled"
-                                  :waiting="isWaiting"
-                                  :error="hasError"
-                                  :valid="isValid"
-                                  :error-message="errorMessage"
-                                  :valid-message="validMessage"
-                                  :helper-message="helperMessage"></m-validation-message>
         </div>
+    </template>
+
+    <template #validation-message>
+        <m-validation-message class="m-select__validation-message"
+                              :class="{ 'm--has-validation-message': hasValidationMessage }"
+                              :disabled="isDisabled"
+                              :waiting="isWaiting"
+                              :error="hasError"
+                              :valid="isValid"
+                              :error-message="errorMessage"
+                              :valid-message="validMessage"
+                              :helper-message="helperMessage"></m-validation-message>
     </template>
 
     <template #outer-items="{items, getItemProps, getItemHandlers}">

--- a/packages/modul-components/src/components/select/select.scss
+++ b/packages/modul-components/src/components/select/select.scss
@@ -8,12 +8,6 @@
         outline: 0 solid transparent;
     }
 
-    &.m--has-validation-message {
-        .m-select__validation-message {
-            margin-top: $m-spacing--xs;
-        }
-    }
-
     &:not(.m--is-disabled) {
         .m-select__arrow {
             cursor: pointer;
@@ -52,5 +46,9 @@
 
     &__validation-message {
         transition: margin-top $m-transition-duration ease;
+
+        &.m--has-validation-message {
+            margin-top: $m-spacing--xs;
+        }
     }
 }

--- a/packages/modul-components/src/components/typeahead/typeahead.html
+++ b/packages/modul-components/src/components/typeahead/typeahead.html
@@ -1,8 +1,7 @@
 <div class="m-typeahead"
      :class="{ 'm--is-results-window-open': isResultsPopupOpen,
    'm--is-disabled': isDisabled,
-   'm--is-waiting': isWaiting,
-   'm--has-validation-message': hasValidationMessage }"
+   'm--is-waiting': isWaiting }"
      :style="{ width: inputWidth, maxWidth: inputMaxWidth }">
     <m-base-select :control-id="id"
                    :active="active"
@@ -53,7 +52,11 @@
                     </div>
                 </template>
             </m-textfield>
+        </template>
+
+        <template #validation-message>
             <m-validation-message class="m-typeahead__validation-message"
+                                  :class="{ 'm--has-validation-message': hasValidationMessage }"
                                   :disabled="isDisabled"
                                   :waiting="isWaiting"
                                   :error="hasError"
@@ -62,6 +65,7 @@
                                   :valid-message="validMessage"
                                   :helper-message="helperMessage"></m-validation-message>
         </template>
+
         <template v-slot:popup-header="scope"
                   v-if="isMqMaxS">
             <h2 class="m-typeahead__label-popup"

--- a/packages/modul-components/src/components/typeahead/typeahead.scss
+++ b/packages/modul-components/src/components/typeahead/typeahead.scss
@@ -1,4 +1,4 @@
-@import 'commons';
+@import "commons";
 
 .m-typeahead {
     @include m-input-inline-spacing();
@@ -35,10 +35,8 @@
 
     &__validation-message {
         transition: margin-top $m-transition-duration ease;
-    }
 
-    &.m--has-validation-message {
-        .m-typeahead__validation-message {
+        &.m--has-validation-message {
             margin-top: $m-spacing--xs;
         }
     }

--- a/src/storybook/src/modul-components/components/form/__snapshots__/form.all-fields.stories.ts.snap
+++ b/src/storybook/src/modul-components/components/form/__snapshots__/form.all-fields.stories.ts.snap
@@ -1522,15 +1522,15 @@ exports[`Storyshots modul-components|m-form/all fields Multi Select 1`] = `
             <!---->
           </div>
         </div>
-         
-        <div
-          class="m-validation-message m-multi-select__validation-message"
-        >
-          <!---->
-           
-          <!---->
-        </div>
       </div>
+    </div>
+     
+    <div
+      class="m-validation-message m-multi-select__validation-message"
+    >
+      <!---->
+       
+      <!---->
     </div>
      
     <div

--- a/src/storybook/src/modul-components/components/form/sandboxes/form-complex.sandbox.html
+++ b/src/storybook/src/modul-components/components/form/sandboxes/form-complex.sandbox.html
@@ -54,14 +54,7 @@
                   label="Fruits"
                   :required-marker="true"
                   :error="selectField.hasError()"
-                  :error-message="selectField.errorMessage"></m-select> <br />
-
-        <m-rich-text-editor v-m-control="richTextField"
-                            v-model="richTextField.value"
-                            label="Directives"
-                            :required-marker="true"
-                            :error="richTextField.hasError()"
-                            :error-message="richTextField.errorMessage"></m-rich-text-editor>
+                  :error-message="selectField.errorMessage"></m-select>
 
         <h4 class="m-u--h6">Nested formgroup</h4>
 

--- a/src/storybook/src/modul-components/components/form/sandboxes/form-complex.sandbox.html
+++ b/src/storybook/src/modul-components/components/form/sandboxes/form-complex.sandbox.html
@@ -54,8 +54,14 @@
                   label="Fruits"
                   :required-marker="true"
                   :error="selectField.hasError()"
-                  :error-message="selectField.errorMessage"></m-select>
+                  :error-message="selectField.errorMessage"></m-select> <br />
 
+        <m-rich-text-editor v-m-control="richTextField"
+                            v-model="richTextField.value"
+                            label="Directives"
+                            :required-marker="true"
+                            :error="richTextField.hasError()"
+                            :error-message="richTextField.errorMessage"></m-rich-text-editor>
 
         <h4 class="m-u--h6">Nested formgroup</h4>
 

--- a/src/storybook/src/modul-components/components/form/sandboxes/form-complex.sandbox.ts
+++ b/src/storybook/src/modul-components/components/form/sandboxes/form-complex.sandbox.ts
@@ -1,5 +1,7 @@
 import { FORM_NAME } from '@ulaval/modul-components/dist/components/component-names';
 import FormPlugin from '@ulaval/modul-components/dist/components/form/form.plugin';
+import RichTextLicensePlugin from '@ulaval/modul-components/dist/components/rich-text-editor/rich-text-license-plugin';
+import { MRichText } from '@ulaval/modul-components/dist/components/rich-text/rich-text';
 import { AbstractControl } from '@ulaval/modul-components/dist/utils/form/abstract-control';
 import { ControlValidatorValidationType } from '@ulaval/modul-components/dist/utils/form/control-validator-validation-type';
 import { FormArray } from '@ulaval/modul-components/dist/utils/form/form-array';
@@ -13,6 +15,12 @@ import { ModulVue } from '@ulaval/modul-components/dist/utils/vue/vue';
 import { PluginObject } from 'vue';
 import { Component, Watch } from 'vue-property-decorator';
 import WithRender from './form-complex.sandbox.html';
+
+// We should always load the rte as a separe chunk because of its size (> 1Mb)
+
+const rteChunk = (): Promise<any> => import(/* webpackChunkName: "rte" */ '@ulaval/modul-components/dist/components/rich-text-editor/rich-text-editor').then((exports: any) => {
+    return exports.MRichTextEditor;
+});
 
 const ID_FORM_NAME: string = 'name';
 const ID_FORM_DESCRIPTION: string = 'description';
@@ -29,6 +37,7 @@ const ID_FORM_CLIENT: string = 'client';
 const ID_FORM_APPLES: string = 'apples';
 const ID_FORM_BANANAS: string = 'bananas';
 const ID_FORM_FRUITS: string = 'fruits';
+const ID_FORM_RICH_TEXT: string = 'rich-text';
 
 class Validations {
     static validatePickingLessThen24Bananas: (options?: ControlValidatorOptions) => ControlValidator = (options?: ControlValidatorOptions): ControlValidator => {
@@ -65,7 +74,9 @@ class Validations {
 }
 
 @WithRender
-@Component
+@Component({
+    components: { 'm-rich-text-editor': rteChunk, MRichText }
+})
 export class MFormAllSandbox extends ModulVue {
     types: string[] = ['douce', 'blanche', 'sec'];
 
@@ -85,7 +96,8 @@ export class MFormAllSandbox extends ModulVue {
         [ID_FORM_ITEMS]: [
             { [ID_FORM_CLIENT]: 'Joe', [ID_FORM_APPLES]: 4, [ID_FORM_BANANAS]: 10 },
             { [ID_FORM_CLIENT]: 'John', [ID_FORM_APPLES]: 3, [ID_FORM_BANANAS]: 11 }
-        ]
+        ],
+        [ID_FORM_RICH_TEXT]: '<p>Bla Bla Bla</p>'
     };
 
     formGroup: FormGroup = this.buildFormGroup();
@@ -108,6 +120,10 @@ export class MFormAllSandbox extends ModulVue {
 
     get selectField(): AbstractControl<string> {
         return this.formGroup.getControl<string>(ID_FORM_SELECT);
+    }
+
+    get richTextField(): AbstractControl<string> {
+        return this.formGroup.getControl<string>(ID_FORM_RICH_TEXT);
     }
 
     get champSupplActive(): AbstractControl<boolean> {
@@ -245,6 +261,14 @@ export class MFormAllSandbox extends ModulVue {
                     initialValue: data[ID_FORM_SELECT] ? data[ID_FORM_SELECT] : ''
                 }
             ),
+            [ID_FORM_RICH_TEXT]: new FormControl<string>(
+                [
+                    RequiredValidator()
+                ],
+                {
+                    initialValue: data[ID_FORM_RICH_TEXT] ? data[ID_FORM_RICH_TEXT] : ''
+                }
+            ),
             [ID_FORM_CHAMP_SUPPL_ACTIVE]: new FormControl<boolean>([],
                 {
                     initialValue: data[ID_FORM_CHAMP_SUPPL_ACTIVE] ? data[ID_FORM_CHAMP_SUPPL_ACTIVE] : false
@@ -319,6 +343,7 @@ export class MFormAllSandbox extends ModulVue {
 const FormAllSandboxPlugin: PluginObject<any> = {
     install(v, options): void {
         v.use(FormPlugin);
+        v.use(RichTextLicensePlugin, { key: `test` });
         v.component(`${FORM_NAME}-complex-sandbox`, MFormAllSandbox);
     }
 };

--- a/src/storybook/src/modul-components/components/form/sandboxes/form-complex.sandbox.ts
+++ b/src/storybook/src/modul-components/components/form/sandboxes/form-complex.sandbox.ts
@@ -1,7 +1,5 @@
 import { FORM_NAME } from '@ulaval/modul-components/dist/components/component-names';
 import FormPlugin from '@ulaval/modul-components/dist/components/form/form.plugin';
-import RichTextLicensePlugin from '@ulaval/modul-components/dist/components/rich-text-editor/rich-text-license-plugin';
-import { MRichText } from '@ulaval/modul-components/dist/components/rich-text/rich-text';
 import { AbstractControl } from '@ulaval/modul-components/dist/utils/form/abstract-control';
 import { ControlValidatorValidationType } from '@ulaval/modul-components/dist/utils/form/control-validator-validation-type';
 import { FormArray } from '@ulaval/modul-components/dist/utils/form/form-array';
@@ -15,12 +13,6 @@ import { ModulVue } from '@ulaval/modul-components/dist/utils/vue/vue';
 import { PluginObject } from 'vue';
 import { Component, Watch } from 'vue-property-decorator';
 import WithRender from './form-complex.sandbox.html';
-
-// We should always load the rte as a separe chunk because of its size (> 1Mb)
-
-const rteChunk = (): Promise<any> => import(/* webpackChunkName: "rte" */ '@ulaval/modul-components/dist/components/rich-text-editor/rich-text-editor').then((exports: any) => {
-    return exports.MRichTextEditor;
-});
 
 const ID_FORM_NAME: string = 'name';
 const ID_FORM_DESCRIPTION: string = 'description';
@@ -37,7 +29,6 @@ const ID_FORM_CLIENT: string = 'client';
 const ID_FORM_APPLES: string = 'apples';
 const ID_FORM_BANANAS: string = 'bananas';
 const ID_FORM_FRUITS: string = 'fruits';
-const ID_FORM_RICH_TEXT: string = 'rich-text';
 
 class Validations {
     static validatePickingLessThen24Bananas: (options?: ControlValidatorOptions) => ControlValidator = (options?: ControlValidatorOptions): ControlValidator => {
@@ -74,9 +65,7 @@ class Validations {
 }
 
 @WithRender
-@Component({
-    components: { 'm-rich-text-editor': rteChunk, MRichText }
-})
+@Component
 export class MFormAllSandbox extends ModulVue {
     types: string[] = ['douce', 'blanche', 'sec'];
 
@@ -96,8 +85,7 @@ export class MFormAllSandbox extends ModulVue {
         [ID_FORM_ITEMS]: [
             { [ID_FORM_CLIENT]: 'Joe', [ID_FORM_APPLES]: 4, [ID_FORM_BANANAS]: 10 },
             { [ID_FORM_CLIENT]: 'John', [ID_FORM_APPLES]: 3, [ID_FORM_BANANAS]: 11 }
-        ],
-        [ID_FORM_RICH_TEXT]: '<p>Bla Bla Bla</p>'
+        ]
     };
 
     formGroup: FormGroup = this.buildFormGroup();
@@ -120,10 +108,6 @@ export class MFormAllSandbox extends ModulVue {
 
     get selectField(): AbstractControl<string> {
         return this.formGroup.getControl<string>(ID_FORM_SELECT);
-    }
-
-    get richTextField(): AbstractControl<string> {
-        return this.formGroup.getControl<string>(ID_FORM_RICH_TEXT);
     }
 
     get champSupplActive(): AbstractControl<boolean> {
@@ -261,14 +245,6 @@ export class MFormAllSandbox extends ModulVue {
                     initialValue: data[ID_FORM_SELECT] ? data[ID_FORM_SELECT] : ''
                 }
             ),
-            [ID_FORM_RICH_TEXT]: new FormControl<string>(
-                [
-                    RequiredValidator()
-                ],
-                {
-                    initialValue: data[ID_FORM_RICH_TEXT] ? data[ID_FORM_RICH_TEXT] : ''
-                }
-            ),
             [ID_FORM_CHAMP_SUPPL_ACTIVE]: new FormControl<boolean>([],
                 {
                     initialValue: data[ID_FORM_CHAMP_SUPPL_ACTIVE] ? data[ID_FORM_CHAMP_SUPPL_ACTIVE] : false
@@ -343,7 +319,6 @@ export class MFormAllSandbox extends ModulVue {
 const FormAllSandboxPlugin: PluginObject<any> = {
     install(v, options): void {
         v.use(FormPlugin);
-        v.use(RichTextLicensePlugin, { key: `test` });
         v.component(`${FORM_NAME}-complex-sandbox`, MFormAllSandbox);
     }
 };

--- a/src/storybook/src/modul-components/components/multi-select/__snapshots__/multi-select.stories.ts.snap
+++ b/src/storybook/src/modul-components/components/multi-select/__snapshots__/multi-select.stories.ts.snap
@@ -92,15 +92,15 @@ exports[`Storyshots modul-components|m-multi-select 500px width 1`] = `
           <!---->
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-multi-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-multi-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -209,15 +209,15 @@ exports[`Storyshots modul-components|m-multi-select Full width 1`] = `
           <!---->
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-multi-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-multi-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -327,15 +327,15 @@ exports[`Storyshots modul-components|m-multi-select Large width 1`] = `
           <!---->
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-multi-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-multi-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -445,15 +445,15 @@ exports[`Storyshots modul-components|m-multi-select complete 1`] = `
           <!---->
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-multi-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-multi-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -594,15 +594,15 @@ exports[`Storyshots modul-components|m-multi-select custom chip info 1`] = `
           <!---->
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-multi-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-multi-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -745,15 +745,15 @@ exports[`Storyshots modul-components|m-multi-select custom select-item 1`] = `
           <!---->
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-multi-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-multi-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -896,15 +896,151 @@ exports[`Storyshots modul-components|m-multi-select default 1`] = `
           <!---->
         </div>
       </div>
+    </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-multi-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
+  </div>
+   
+  <div
+    class="m-popup"
+  >
+    <div
+      class="m-popper"
+    >
        
+      <!---->
+    </div>
+     
+    <!---->
+  </div>
+</div>
+`;
+
+exports[`Storyshots modul-components|m-multi-select error-message 1`] = `
+<div
+  class="m-base-select"
+  input-max-width="288px"
+  style="width: 100%; max-width: 288px;"
+>
+  <div
+    class="m-base-select__popup"
+  >
+    <div
+      class="m-multi-select"
+      style="width: 100%; max-width: 288px;"
+      tabindex="0"
+    >
       <div
-        class="m-validation-message m-multi-select__validation-message"
+        class="m-input-style m--has-cursor-pointer m--has-error m--is-tag-default"
+        style="margin-top: 10px;"
       >
-        <!---->
-         
-        <!---->
+        <div
+          class="m-input-style__main"
+        >
+          <div
+            class="m-input-style__body"
+          >
+            <span
+              class="m-input-style__label"
+              style="z-index: -1;"
+            >
+              <span
+                class="m-input-style__text"
+              />
+            </span>
+             
+            <div
+              class="m-input-style__input"
+            >
+              <div
+                class="m-input-style__prefix"
+              />
+               
+              <div
+                class="m-input-style__content"
+              >
+                <div
+                  class="m-multi-select__chips"
+                >
+                  <input
+                    readonly="readonly"
+                    type="text"
+                  />
+                   
+                </div>
+                  
+                <!---->
+                 
+                <!---->
+              </div>
+               
+              <div
+                class="m-input-style__suffix"
+              >
+                <div
+                  class="m-multi-select__arrow"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="m-icon m-multi-select__arrow__icon"
+                    height="16px"
+                    width="16px"
+                  >
+                    <!---->
+                     
+                    <use
+                      aria-hidden="true"
+                      class=""
+                    />
+                  </svg>
+                </div>
+                 
+                <!---->
+              </div>
+            </div>
+          </div>
+           
+          <!---->
+        </div>
       </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-multi-select__validation-message m--has-validation-message"
+  >
+    <p
+      class="m-validation-message__error"
+    >
+      <svg
+        class="m-icon m-validation-message__icon"
+        height="1em"
+        width="1em"
+      >
+        <title>
+          Erreur
+        </title>
+         
+        <use
+          aria-hidden="true"
+          class=""
+        />
+      </svg>
+       
+      <span
+        class="m-validation-message__text"
+      >
+        Error message
+      </span>
+    </p>
+     
+    <!---->
   </div>
    
   <div
@@ -1052,15 +1188,15 @@ exports[`Storyshots modul-components|m-multi-select label 1`] = `
           <!---->
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-multi-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-multi-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -1171,15 +1307,15 @@ exports[`Storyshots modul-components|m-multi-select object as options 1`] = `
             <!---->
           </div>
         </div>
-         
-        <div
-          class="m-validation-message m-multi-select__validation-message"
-        >
-          <!---->
-           
-          <!---->
-        </div>
       </div>
+    </div>
+     
+    <div
+      class="m-validation-message m-multi-select__validation-message"
+    >
+      <!---->
+       
+      <!---->
     </div>
      
     <div
@@ -1294,15 +1430,15 @@ exports[`Storyshots modul-components|m-multi-select placeholder 1`] = `
           <!---->
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-multi-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-multi-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -1445,15 +1581,15 @@ exports[`Storyshots modul-components|m-multi-select select all link 1`] = `
           <!---->
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-multi-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-multi-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -1558,15 +1694,15 @@ exports[`Storyshots modul-components|m-multi-select/mobile iphone6 - select all 
           <!---->
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-multi-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-multi-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -1671,15 +1807,15 @@ exports[`Storyshots modul-components|m-multi-select/mobile iphone6 1`] = `
           <!---->
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-multi-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-multi-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div

--- a/src/storybook/src/modul-components/components/multi-select/multi-select.stories.ts
+++ b/src/storybook/src/modul-components/components/multi-select/multi-select.stories.ts
@@ -232,3 +232,20 @@ storiesOf(`${modulComponentsHierarchyRootSeparator}${MULTI_SELECT_NAME}`, module
         template: `<m-multi-select placeholder="A very very very very very very looooong" @open="open" @close="close" @focus="focus" @blur="blur" @select-item="select" :options="options" v-model="model1"></m-multi-select>`
     })
     );
+
+storiesOf(`${modulComponentsHierarchyRootSeparator}${MULTI_SELECT_NAME}`, module)
+    .add('error-message', () => ({
+        methods: actions(
+            'open',
+            'close',
+            'focus',
+            'blur',
+            'select'
+        ),
+        data: () => ({
+            model1: [],
+            options: optionsVonTrapp
+        }),
+        template: `<m-multi-select error-message="Error message" @open="open" @close="close" @focus="focus" @blur="blur" @select-item="select" :options="options" v-model="model1"></m-multi-select>`
+    })
+    );

--- a/src/storybook/src/modul-components/components/phonefield/__snapshots__/phonefield.stories.ts.snap
+++ b/src/storybook/src/modul-components/components/phonefield/__snapshots__/phonefield.stories.ts.snap
@@ -110,15 +110,15 @@ exports[`Storyshots modul-components|m-phonefield Autocomplete Work Phone 1`] = 
               </div>
             </div>
           </div>
-           
-          <div
-            class="m-validation-message m-select__validation-message"
-          >
-            <!---->
-             
-            <!---->
-          </div>
         </div>
+      </div>
+       
+      <div
+        class="m-validation-message m-select__validation-message"
+      >
+        <!---->
+         
+        <!---->
       </div>
        
       <div
@@ -308,15 +308,15 @@ exports[`Storyshots modul-components|m-phonefield Detect Country 1`] = `
               </div>
             </div>
           </div>
-           
-          <div
-            class="m-validation-message m-select__validation-message"
-          >
-            <!---->
-             
-            <!---->
-          </div>
         </div>
+      </div>
+       
+      <div
+        class="m-validation-message m-select__validation-message"
+      >
+        <!---->
+         
+        <!---->
       </div>
        
       <div
@@ -458,15 +458,15 @@ exports[`Storyshots modul-components|m-phonefield Detect Country 1`] = `
                   </div>
                 </div>
               </div>
-               
-              <div
-                class="m-validation-message m-select__validation-message"
-              >
-                <!---->
-                 
-                <!---->
-              </div>
             </div>
+          </div>
+           
+          <div
+            class="m-validation-message m-select__validation-message"
+          >
+            <!---->
+             
+            <!---->
           </div>
            
           <div
@@ -682,15 +682,15 @@ exports[`Storyshots modul-components|m-phonefield Disabled 1`] = `
               </div>
             </div>
           </div>
-           
-          <div
-            class="m-validation-message m-select__validation-message"
-          >
-            <!---->
-             
-            <!---->
-          </div>
         </div>
+      </div>
+       
+      <div
+        class="m-validation-message m-select__validation-message"
+      >
+        <!---->
+         
+        <!---->
       </div>
        
       <div
@@ -896,15 +896,15 @@ exports[`Storyshots modul-components|m-phonefield Error 1`] = `
               </div>
             </div>
           </div>
-           
-          <div
-            class="m-validation-message m-select__validation-message"
-          >
-            <!---->
-             
-            <!---->
-          </div>
         </div>
+      </div>
+       
+      <div
+        class="m-validation-message m-select__validation-message"
+      >
+        <!---->
+         
+        <!---->
       </div>
        
       <div
@@ -1109,15 +1109,15 @@ exports[`Storyshots modul-components|m-phonefield Error Message 1`] = `
               </div>
             </div>
           </div>
-           
-          <div
-            class="m-validation-message m-select__validation-message"
-          >
-            <!---->
-             
-            <!---->
-          </div>
         </div>
+      </div>
+       
+      <div
+        class="m-validation-message m-select__validation-message"
+      >
+        <!---->
+         
+        <!---->
       </div>
        
       <div
@@ -1345,15 +1345,15 @@ exports[`Storyshots modul-components|m-phonefield Full Width 1`] = `
               </div>
             </div>
           </div>
-           
-          <div
-            class="m-validation-message m-select__validation-message"
-          >
-            <!---->
-             
-            <!---->
-          </div>
         </div>
+      </div>
+       
+      <div
+        class="m-validation-message m-select__validation-message"
+      >
+        <!---->
+         
+        <!---->
       </div>
        
       <div
@@ -1558,15 +1558,15 @@ exports[`Storyshots modul-components|m-phonefield Max Width 500 Px 1`] = `
               </div>
             </div>
           </div>
-           
-          <div
-            class="m-validation-message m-select__validation-message"
-          >
-            <!---->
-             
-            <!---->
-          </div>
         </div>
+      </div>
+       
+      <div
+        class="m-validation-message m-select__validation-message"
+      >
+        <!---->
+         
+        <!---->
       </div>
        
       <div
@@ -1771,15 +1771,15 @@ exports[`Storyshots modul-components|m-phonefield Max Width Large 1`] = `
               </div>
             </div>
           </div>
-           
-          <div
-            class="m-validation-message m-select__validation-message"
-          >
-            <!---->
-             
-            <!---->
-          </div>
         </div>
+      </div>
+       
+      <div
+        class="m-validation-message m-select__validation-message"
+      >
+        <!---->
+         
+        <!---->
       </div>
        
       <div
@@ -1984,15 +1984,15 @@ exports[`Storyshots modul-components|m-phonefield Other Default Country 1`] = `
               </div>
             </div>
           </div>
-           
-          <div
-            class="m-validation-message m-select__validation-message"
-          >
-            <!---->
-             
-            <!---->
-          </div>
         </div>
+      </div>
+       
+      <div
+        class="m-validation-message m-select__validation-message"
+      >
+        <!---->
+         
+        <!---->
       </div>
        
       <div
@@ -2197,15 +2197,15 @@ exports[`Storyshots modul-components|m-phonefield Priority Countries Defined Fr 
               </div>
             </div>
           </div>
-           
-          <div
-            class="m-validation-message m-select__validation-message"
-          >
-            <!---->
-             
-            <!---->
-          </div>
         </div>
+      </div>
+       
+      <div
+        class="m-validation-message m-select__validation-message"
+      >
+        <!---->
+         
+        <!---->
       </div>
        
       <div
@@ -2410,15 +2410,15 @@ exports[`Storyshots modul-components|m-phonefield Priority Countries Empty 1`] =
               </div>
             </div>
           </div>
-           
-          <div
-            class="m-validation-message m-select__validation-message"
-          >
-            <!---->
-             
-            <!---->
-          </div>
         </div>
+      </div>
+       
+      <div
+        class="m-validation-message m-select__validation-message"
+      >
+        <!---->
+         
+        <!---->
       </div>
        
       <div
@@ -2624,15 +2624,15 @@ exports[`Storyshots modul-components|m-phonefield Waiting 1`] = `
               </div>
             </div>
           </div>
-           
-          <div
-            class="m-validation-message m-select__validation-message"
-          >
-            <!---->
-             
-            <!---->
-          </div>
         </div>
+      </div>
+       
+      <div
+        class="m-validation-message m-select__validation-message"
+      >
+        <!---->
+         
+        <!---->
       </div>
        
       <div

--- a/src/storybook/src/modul-components/components/select-virtual-scroll/__snapshots__/select-virtual-scroll.stories.ts.snap
+++ b/src/storybook/src/modul-components/components/select-virtual-scroll/__snapshots__/select-virtual-scroll.stories.ts.snap
@@ -95,15 +95,15 @@ exports[`Storyshots modul-components|m-select-virtual-scroll Default 1`] = `
           </div>
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -216,15 +216,15 @@ exports[`Storyshots modul-components|m-select-virtual-scroll Virtual Scroll 1`] 
           </div>
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div

--- a/src/storybook/src/modul-components/components/select/__snapshots__/select.stories.ts.snap
+++ b/src/storybook/src/modul-components/components/select/__snapshots__/select.stories.ts.snap
@@ -93,15 +93,15 @@ exports[`Storyshots modul-components|m-select Clearable 1`] = `
           </div>
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -216,15 +216,15 @@ exports[`Storyshots modul-components|m-select Clearable And Required Marker 1`] 
           </div>
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -339,15 +339,15 @@ exports[`Storyshots modul-components|m-select Clearable False And Required Marke
           </div>
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -459,15 +459,15 @@ exports[`Storyshots modul-components|m-select Default 1`] = `
           </div>
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -579,15 +579,15 @@ exports[`Storyshots modul-components|m-select Disabled Item Selected With Label 
           </div>
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -699,15 +699,15 @@ exports[`Storyshots modul-components|m-select Disabled Item Selected With Label 
           </div>
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -814,15 +814,15 @@ exports[`Storyshots modul-components|m-select Disabled No Selection No Label 1`]
           </div>
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -930,15 +930,15 @@ exports[`Storyshots modul-components|m-select Disabled No Selection No Label Wit
           </div>
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -1050,15 +1050,15 @@ exports[`Storyshots modul-components|m-select Disabled No Selection With Label 1
           </div>
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -1171,15 +1171,152 @@ exports[`Storyshots modul-components|m-select Disabled No Selection With Label W
           </div>
         </div>
       </div>
+    </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
+  </div>
+   
+  <div
+    class="m-popup"
+  >
+    <div
+      class="m-popper"
+    >
        
+      <!---->
+    </div>
+     
+    <!---->
+  </div>
+</div>
+`;
+
+exports[`Storyshots modul-components|m-select Error Message 1`] = `
+<div
+  class="m-base-select"
+  style="width: 100%; max-width: 288px;"
+>
+  <div
+    class="m-base-select__popup"
+  >
+    <div
+      class="m-select"
+      style="width: 100%; max-width: regular;"
+      tabindex="0"
+    >
       <div
-        class="m-validation-message m-select__validation-message"
+        class="m-input-style m--has-cursor-pointer m--has-error m--is-tag-default"
+        style="width: 100%; margin-top: 10px;"
       >
-        <!---->
-         
-        <!---->
+        <div
+          class="m-input-style__main"
+        >
+          <div
+            class="m-input-style__body"
+          >
+            <span
+              class="m-input-style__label"
+              style="z-index: -1;"
+            >
+              <span
+                class="m-input-style__text"
+              />
+            </span>
+             
+            <div
+              class="m-input-style__input"
+            >
+              <div
+                class="m-input-style__prefix"
+              />
+               
+              <div
+                class="m-input-style__content"
+              >
+                <div>
+                  <input
+                    readonly="readonly"
+                    tabindex="-1"
+                  />
+                </div>
+                 
+                <!---->
+                 
+                <!---->
+              </div>
+               
+              <div
+                class="m-input-style__suffix"
+              >
+                 
+                <!---->
+              </div>
+            </div>
+          </div>
+           
+          <div
+            class="m-input-style__append"
+          >
+            <!---->
+             
+            <div
+              class="m-select__arrow"
+            >
+              <svg
+                aria-hidden="true"
+                class="m-icon m-select__arrow__icon"
+                height="12px"
+                width="12px"
+              >
+                <!---->
+                 
+                <use
+                  aria-hidden="true"
+                  class=""
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-select__validation-message m--has-validation-message"
+  >
+    <p
+      class="m-validation-message__error"
+    >
+      <svg
+        class="m-icon m-validation-message__icon"
+        height="1em"
+        width="1em"
+      >
+        <title>
+          Erreur
+        </title>
+         
+        <use
+          aria-hidden="true"
+          class=""
+        />
+      </svg>
+       
+      <span
+        class="m-validation-message__text"
+      >
+        Error message
+      </span>
+    </p>
+     
+    <!---->
   </div>
    
   <div
@@ -1285,15 +1422,15 @@ exports[`Storyshots modul-components|m-select Focus 1`] = `
           </div>
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -1426,15 +1563,15 @@ exports[`Storyshots modul-components|m-select Full Width 1`] = `
           </div>
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -1545,15 +1682,15 @@ exports[`Storyshots modul-components|m-select Label 1`] = `
           </div>
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -1664,15 +1801,15 @@ exports[`Storyshots modul-components|m-select Label Up 1`] = `
           </div>
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -1783,15 +1920,15 @@ exports[`Storyshots modul-components|m-select Long Option Menu 1`] = `
           </div>
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -1924,15 +2061,15 @@ exports[`Storyshots modul-components|m-select Max Width 500 Px 1`] = `
           </div>
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -2065,15 +2202,15 @@ exports[`Storyshots modul-components|m-select Max Width Large 1`] = `
           </div>
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -2180,15 +2317,15 @@ exports[`Storyshots modul-components|m-select Placeholder 1`] = `
           </div>
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -2301,15 +2438,15 @@ exports[`Storyshots modul-components|m-select Readonly Item Selected With Label 
           </div>
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -2422,15 +2559,15 @@ exports[`Storyshots modul-components|m-select Readonly Item Selected With Label 
           </div>
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -2538,15 +2675,15 @@ exports[`Storyshots modul-components|m-select Readonly No Selection No Label 1`]
           </div>
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -2654,15 +2791,15 @@ exports[`Storyshots modul-components|m-select Readonly No Selection No Label Wit
           </div>
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -2775,15 +2912,15 @@ exports[`Storyshots modul-components|m-select Readonly No Selection With Label 1
           </div>
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -2896,15 +3033,15 @@ exports[`Storyshots modul-components|m-select Readonly No Selection With Label W
           </div>
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -3019,15 +3156,15 @@ exports[`Storyshots modul-components|m-select Required Marker 1`] = `
           </div>
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -3160,15 +3297,15 @@ exports[`Storyshots modul-components|m-select Selected Item 1`] = `
           </div>
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -3296,15 +3433,15 @@ exports[`Storyshots modul-components|m-select With Items Slot 1`] = `
           </div>
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div
@@ -3432,15 +3569,15 @@ exports[`Storyshots modul-components|m-select With Outer Items Slot 1`] = `
           </div>
         </div>
       </div>
-       
-      <div
-        class="m-validation-message m-select__validation-message"
-      >
-        <!---->
-         
-        <!---->
-      </div>
     </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
   </div>
    
   <div

--- a/src/storybook/src/modul-components/components/select/select.stories.ts
+++ b/src/storybook/src/modul-components/components/select/select.stories.ts
@@ -96,6 +96,14 @@ export const placeholder = () => ({
     template: `<m-select v-model="model" :options="options" placeholder="Choose a Fruit" ></m-select>`
 });
 
+export const errorMessage = () => ({
+    data: () => ({
+        options: OPTIONS,
+        model: ''
+    }),
+    template: `<m-select v-model="model" :options="options" error-message="Error message" ></m-select>`
+});
+
 export const labelUp = () => ({
     data: () => ({
         options: OPTIONS,

--- a/src/storybook/src/modul-components/components/typeahead/__snapshots__/typeahead.stories.ts.snap
+++ b/src/storybook/src/modul-components/components/typeahead/__snapshots__/typeahead.stories.ts.snap
@@ -97,14 +97,14 @@ exports[`Storyshots modul-components|m-typeahead Default 1`] = `
             <!---->
           </div>
         </div>
+      </div>
+       
+      <div
+        class="m-validation-message m-typeahead__validation-message"
+      >
+        <!---->
          
-        <div
-          class="m-validation-message m-typeahead__validation-message"
-        >
-          <!---->
-           
-          <!---->
-        </div>
+        <!---->
       </div>
        
       <div
@@ -249,14 +249,14 @@ exports[`Storyshots modul-components|m-typeahead custom results 1`] = `
             <!---->
           </div>
         </div>
+      </div>
+       
+      <div
+        class="m-validation-message m-typeahead__validation-message"
+      >
+        <!---->
          
-        <div
-          class="m-validation-message m-typeahead__validation-message"
-        >
-          <!---->
-           
-          <!---->
-        </div>
+        <!---->
       </div>
        
       <div
@@ -273,6 +273,181 @@ exports[`Storyshots modul-components|m-typeahead custom results 1`] = `
       </div>
     </div>
   </div>
+</div>
+`;
+
+exports[`Storyshots modul-components|m-typeahead error-message 1`] = `
+<div>
+  <div
+    class="m-typeahead"
+    style="width: 100%; max-width: 288px;"
+  >
+    <div
+      class="m-base-select"
+      input-max-width="288px"
+      style="width: 100%; max-width: 288px;"
+    >
+      <div
+        class="m-base-select__popup"
+      >
+        <div
+          aria-controls="m-typeahead-fakeId-controls"
+          aria-haspopup="true"
+          class="m-textfield m--has-error m--has-label m--is-type-text"
+          cursor-pointer="true"
+          style="width: 100%; max-width: 288px;"
+        >
+          <div
+            class="m-input-style m--has-error m--has-label m--is-tag-default"
+            style="margin-top: 10px;"
+          >
+            <div
+              class="m-input-style__main"
+            >
+              <div
+                class="m-input-style__body"
+              >
+                <label
+                  class="m-input-style__label"
+                  for="mTextfield-fakeId"
+                  style="margin-right: 0px;"
+                >
+                  <span
+                    class="m-input-style__text"
+                  >
+                    <span>
+                      Fruits and vegetables
+                    </span>
+                     
+                    <!---->
+                  </span>
+                </label>
+                 
+                <div
+                  class="m-input-style__input"
+                >
+                  <!---->
+                   
+                  <div
+                    class="m-input-style__content"
+                  >
+                    <input
+                      class="m-textfield__input"
+                      id="mTextfield-fakeId"
+                      maxlength="Infinity"
+                      type="text"
+                    />
+                       
+                    <!---->
+                     
+                    <!---->
+                     
+                    <!---->
+                  </div>
+                   
+                  <div
+                    class="m-input-style__suffix"
+                  >
+                    <!---->
+                     
+                    <!---->
+                  </div>
+                </div>
+              </div>
+               
+              <!---->
+            </div>
+          </div>
+           
+          <div
+            class="m-textfield__validation"
+          >
+            <div
+              class="m-validation-message m-textfield__validation__message"
+            >
+              <!---->
+               
+              <!---->
+            </div>
+             
+            <!---->
+          </div>
+        </div>
+      </div>
+       
+      <div
+        class="m-validation-message m-typeahead__validation-message m--has-validation-message"
+      >
+        <p
+          class="m-validation-message__error"
+        >
+          <svg
+            class="m-icon m-validation-message__icon"
+            height="1em"
+            width="1em"
+          >
+            <title>
+              Erreur
+            </title>
+             
+            <use
+              aria-hidden="true"
+              class=""
+            />
+          </svg>
+           
+          <span
+            class="m-validation-message__text"
+          >
+            Error message
+          </span>
+        </p>
+         
+        <!---->
+      </div>
+       
+      <div
+        class="m-popup"
+      >
+        <div
+          class="m-popper"
+        >
+           
+          <!---->
+        </div>
+         
+        <!---->
+      </div>
+    </div>
+  </div>
+   
+  <p>
+    maxResult = 5
+  </p>
+   
+  <h2
+    class="m-u--h5"
+  >
+    Values
+  </h2>
+   
+  <p>
+    [
+  "Apple",
+  "Avocados",
+  "Bannana",
+  "Beet",
+  "Carrot",
+  "Celery",
+  "Eggplant",
+  "Kiwi",
+  "Lemon",
+  "Patate",
+  "Pineapple",
+  "Pumpkin",
+  "Tomato"
+]
+  </p>
 </div>
 `;
 
@@ -369,14 +544,14 @@ exports[`Storyshots modul-components|m-typeahead filter-results-manually 1`] = `
             <!---->
           </div>
         </div>
+      </div>
+       
+      <div
+        class="m-validation-message m-typeahead__validation-message"
+      >
+        <!---->
          
-        <div
-          class="m-validation-message m-typeahead__validation-message"
-        >
-          <!---->
-           
-          <!---->
-        </div>
+        <!---->
       </div>
        
       <div
@@ -517,14 +692,14 @@ exports[`Storyshots modul-components|m-typeahead max-results 1`] = `
             <!---->
           </div>
         </div>
+      </div>
+       
+      <div
+        class="m-validation-message m-typeahead__validation-message"
+      >
+        <!---->
          
-        <div
-          class="m-validation-message m-typeahead__validation-message"
-        >
-          <!---->
-           
-          <!---->
-        </div>
+        <!---->
       </div>
        
       <div
@@ -669,14 +844,14 @@ exports[`Storyshots modul-components|m-typeahead/mobile iphone6 1`] = `
             <!---->
           </div>
         </div>
+      </div>
+       
+      <div
+        class="m-validation-message m-typeahead__validation-message"
+      >
+        <!---->
          
-        <div
-          class="m-validation-message m-typeahead__validation-message"
-        >
-          <!---->
-           
-          <!---->
-        </div>
+        <!---->
       </div>
        
       <div

--- a/src/storybook/src/modul-components/components/typeahead/typeahead.stories.ts
+++ b/src/storybook/src/modul-components/components/typeahead/typeahead.stories.ts
@@ -47,6 +47,20 @@ storiesOf(`${modulComponentsHierarchyRootSeparator}${TYPEAHEAD_NAME}`, module)
             <p v-html="results"></p>
         </div>`
     }))
+    .add('error-message', () => ({
+        data: () => ({
+            label: 'Fruits and vegetables',
+            results: RESULTS,
+            value: '',
+            maxResults: 5
+        }),
+        template: `<div>
+            <m-typeahead v-model="value" :label="label" :max-results="maxResults" :results="results" error-message="Error message"></m-typeahead>
+            <p>maxResult = {{ maxResults}}</p>
+            <h2 class="m-u--h5">Values</h2>
+            <p v-html="results"></p>
+        </div>`
+    }))
     .add('custom results', () => ({
         data: () => ({
             label: 'Fruits and vegetables',


### PR DESCRIPTION
<!--
Veuillez consulter les directives de contribution / Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

## Description
Lorsque le m-select a une erreur, le popup s'ouvrait dessous le message d'erreur

## Types de changements
<!--- Indiquez ici quels types de modifications votre code introduit / Indicated here what types of changes does your code introduce -->
- [x] Correction de bug (sans `breaking change`)
- [ ] Amélioration (ajout par example une nouvelle propriété, évènement, slot ou méthode à un composant existant sans `breaking change`)
- [ ] Nouvelle fonctionalité (nouveau composant, directive, filtre ou service)
- [ ] Breaking change (modification à une fonctionnalités existante qui nécessite une migration *remplir la section release note*)
- [ ] Refactoring/ménage (sans `breaking change`)
- [ ] Documentation/storybook (changement à la documentation ou aux storybooks qui n'affecte aucun package)
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Comment cela peut-il être testé?
<!--- Décrivez comment vous avez testé vos modifications / Please describe how you tested your changes -->
- [ ] Test unitaire (un nouveau test unitaire à été fait)
- [x] Storybook
- [ ] Test manuel / Sandboxes
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

<!--  Merci d'avoir contribué! / Thanks for contributing! -->
