### PR TITLE
ENA2-10967 - Use text value internally instead of number to keep lead…

### DIFF
--- a/packages/modul-components/src/components/decimalfield/decimalfield.ts
+++ b/packages/modul-components/src/components/decimalfield/decimalfield.ts
@@ -1,6 +1,6 @@
 import { PluginObject } from 'vue';
 import Component from 'vue-class-component';
-import { Emit, Prop } from 'vue-property-decorator';
+import { Emit, Prop, Watch } from 'vue-property-decorator';
 import { InputLabel } from '../../mixins/input-label/input-label';
 import { InputManagement } from '../../mixins/input-management/input-management';
 import { InputState } from '../../mixins/input-state/input-state';
@@ -44,6 +44,7 @@ export class MDecimalfield extends ModulVue {
     public forceRoundingFormat: boolean;
 
     protected id: string = `mDecimalfield-${uuid.generate()}`;
+    private text: string = '';
 
     private get hasDecimalfieldError(): boolean {
         return this.as<InputState>().hasError;
@@ -74,12 +75,21 @@ export class MDecimalfield extends ModulVue {
     }
 
     private get model(): string {
-        return (!this.value && this.value !== 0 ? '' : this.value).toString();
+        return this.text;
     }
 
     private set model(value: string) {
+        this.text = value;
         const valueAsNumber: number = Number.parseFloat(value);
         this.emitNewValue(valueAsNumber);
+    }
+
+    @Watch('value', { immediate: true })
+    public onValueChange(newValue: number): void {
+        const currentTextAsNumber: number = Number.parseFloat(this.text);
+        if (newValue !== currentTextAsNumber) {
+            this.text = (!newValue && newValue !== 0 ? '' : newValue).toString();
+        }
     }
 
     @Emit('input')


### PR DESCRIPTION
<!--
Veuillez consulter les directives de contribution / Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Content can be written in English or in French
-->

## Description
Je saisi un nombre : 11,01
Je fais 1 SEUL backspace
Résultat obtenu : Le champ est maintenant 11

Résultat attendu : le champ devrait être 11,0

## Types de changements
<!--- Indiquez ici quels types de modifications votre code introduit / Indicated here what types of changes does your code introduce -->
- [ X] Correction de bug (sans `breaking change`)
- [ ] Amélioration (ajout par example une nouvelle propriété, évènement, slot ou méthode à un composant existant sans `breaking change`)
- [ ] Nouvelle fonctionalité (nouveau composant, directive, filtre ou service)
- [ ] Breaking change (modification à une fonctionnalités existante qui nécessite une migration *remplir la section release note*)
- [ ] Refactoring/ménage (sans `breaking change`)
- [ ] Documentation/storybook (changement à la documentation ou aux storybooks qui n'affecte aucun package)
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Comment cela peut-il être testé?
<!--- Décrivez comment vous avez testé vos modifications / Please describe how you tested your changes -->
- [ ] Test unitaire (un nouveau test unitaire à été fait)
- [X ] Storybook
- [ ] Test manuel / Sandboxes
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Inclure cette section dans les release notes
<!-- Pour chaque breaking changes , inscrire la description du changement et les instructions pour la migration -->

## Liens internes
<!-- Si vous êtes un contributeur interne, ajouter les liens vers vos billets Jira. ou déploiement dans openshift -->
Voir https://jira.dti.ulaval.ca/browse/ENA2-10967

<!--  Merci d'avoir contribué! / Thanks for contributing! -->
