### PR TITLE
MMultiSelect - Correction d'affichage lorsque la liste est vide

### DIFF
--- a/packages/modul-components/src/components/multi-select/multi-select.ts
+++ b/packages/modul-components/src/components/multi-select/multi-select.ts
@@ -115,7 +115,7 @@ export class MMultiSelect extends ModulVue {
     }
 
     get allSelected(): boolean {
-        return this.options.length === this.value.length;
+        return this.options.length > 0 && this.options.length === this.value.length;
     }
 
     get chipsDisplayMode(): number {

--- a/src/storybook/src/modul-components/components/multi-select/__snapshots__/multi-select.stories.ts.snap
+++ b/src/storybook/src/modul-components/components/multi-select/__snapshots__/multi-select.stories.ts.snap
@@ -922,6 +922,119 @@ exports[`Storyshots modul-components|m-multi-select default 1`] = `
 </div>
 `;
 
+exports[`Storyshots modul-components|m-multi-select empty 1`] = `
+<div
+  class="m-base-select"
+  input-max-width="288px"
+  style="width: 100%; max-width: 288px;"
+>
+  <div
+    class="m-base-select__popup"
+  >
+    <div
+      class="m-multi-select"
+      style="width: 100%; max-width: 288px;"
+      tabindex="0"
+    >
+      <div
+        class="m-input-style m--has-cursor-pointer m--is-tag-default"
+        style="margin-top: 10px;"
+      >
+        <div
+          class="m-input-style__main"
+        >
+          <div
+            class="m-input-style__body"
+          >
+            <span
+              class="m-input-style__label"
+              style="z-index: -1;"
+            >
+              <span
+                class="m-input-style__text"
+              />
+            </span>
+             
+            <div
+              class="m-input-style__input"
+            >
+              <div
+                class="m-input-style__prefix"
+              />
+               
+              <div
+                class="m-input-style__content"
+              >
+                <div
+                  class="m-multi-select__chips"
+                >
+                  <input
+                    readonly="readonly"
+                    type="text"
+                  />
+                   
+                </div>
+                  
+                <!---->
+                 
+                <!---->
+              </div>
+               
+              <div
+                class="m-input-style__suffix"
+              >
+                <div
+                  class="m-multi-select__arrow"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="m-icon m-multi-select__arrow__icon"
+                    height="16px"
+                    width="16px"
+                  >
+                    <!---->
+                     
+                    <use
+                      aria-hidden="true"
+                      class=""
+                    />
+                  </svg>
+                </div>
+                 
+                <!---->
+              </div>
+            </div>
+          </div>
+           
+          <!---->
+        </div>
+      </div>
+    </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-multi-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
+  </div>
+   
+  <div
+    class="m-popup"
+  >
+    <div
+      class="m-popper"
+    >
+       
+      <!---->
+    </div>
+     
+    <!---->
+  </div>
+</div>
+`;
+
 exports[`Storyshots modul-components|m-multi-select error-message 1`] = `
 <div
   class="m-base-select"

--- a/src/storybook/src/modul-components/components/multi-select/multi-select.stories.ts
+++ b/src/storybook/src/modul-components/components/multi-select/multi-select.stories.ts
@@ -27,6 +27,23 @@ storiesOf(`${modulComponentsHierarchyRootSeparator}${MULTI_SELECT_NAME}`, module
     );
 
 storiesOf(`${modulComponentsHierarchyRootSeparator}${MULTI_SELECT_NAME}`, module)
+    .add('empty', () => ({
+        methods: actions(
+            'open',
+            'close',
+            'focus',
+            'blur',
+            'select'
+        ),
+        data: () => ({
+            model1: [],
+            options: []
+        }),
+        template: `<m-multi-select @open="open" @close="close" @focus="focus" @blur="blur" @select-item="select" :options="options" v-model="model1"></m-multi-select>`
+    })
+    );
+
+storiesOf(`${modulComponentsHierarchyRootSeparator}${MULTI_SELECT_NAME}`, module)
     .add('complete', () => ({
         methods: actions(
             'open',


### PR DESCRIPTION
<!--
Veuillez consulter les directives de contribution / Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Content can be written in English or in French
-->

## Description
<!-- Décrivez brièvement les changements introduits par ce PR / Provide a small description of the changes introduced by this PR -->
Lorsque la liste d'options du multi-select était vide, elle affichait la pastille : [Tous les choix (0) x]. Comme quand toutes les options de la liste sont sélectionnées. J'ai précisé la règle d'affichage de cette pastille pour qu'elle ne s'affiche pas quand il n'y a aucune option dans une liste.

## Types de changements
<!--- Indiquez ici quels types de modifications votre code introduit / Indicated here what types of changes does your code introduce -->
- [ ] Correction de bug (sans `breaking change`)
- [ ] Amélioration (ajout par example une nouvelle propriété, évènement, slot ou méthode à un composant existant sans `breaking change`)
- [ ] Nouvelle fonctionalité (nouveau composant, directive, filtre ou service)
- [ ] Breaking change (modification à une fonctionnalités existante qui nécessite une migration *remplir la section release note*)
- [ ] Refactoring/ménage (sans `breaking change`)
- [ ] Documentation/storybook (changement à la documentation ou aux storybooks qui n'affecte aucun package)
- [x] Autre
Correction de bug avec breaking change visuel
<!-- si vous avez sélectionner autre, préciser ici -->

## Comment cela peut-il être testé?
<!--- Décrivez comment vous avez testé vos modifications / Please describe how you tested your changes -->
- [ ] Test unitaire (un nouveau test unitaire à été fait)
- [x] Storybook
- [ ] Test manuel / Sandboxes
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Inclure cette section dans les release notes
<!-- Pour chaque breaking changes , inscrire la description du changement et les instructions pour la migration -->
La liste déroulante multi-select n'affiche plus la pastille "Tous les choix (0)" lorsqu'il n'y a pas d'options qui lui sont passé

## Liens internes
<!-- Si vous êtes un contributeur interne, ajouter les liens vers vos billets Jira. ou déploiement dans openshift -->

<!--  Merci d'avoir contribué! / Thanks for contributing! -->
