### PR TITLE
[bugfix] m-navbar-item : Correct native click error in mpo-ui

### DIFF
--- a/packages/modul-components/src/components/navbar/navbar-item/navbar-item.html
+++ b/packages/modul-components/src/components/navbar/navbar-item/navbar-item.html
@@ -1,21 +1,20 @@
 <li class="m-navbar-item"
     :class="{'m--is-selected': isSelected,
              'm--is-disabled': disabled }"
-    role="menuitem">
+    role="menuitem"
+    @click="onClick"
+    @mouseover="onMouseover"
+    @mouseleave="onMouseleave">
     <component class="m-navbar-item__contents"
-               :is="(url && !disabled) ? 'router-link' : 'div'"
-               :to="(url && !disabled) ? url : undefined"
+               :is="isRouterLink ? 'router-link' : 'div'"
+               :to="isRouterLink ? url : undefined"
                :aria-selected="isSelected"
                :aria-haspopup="ariaHaspopup"
                :aria-expanded="ariaExpanded"
                :aria-controls="ariaControls"
                :tabindex="(url || disabled) ? undefined : '0'"
                :role="(url || disabled) ? undefined : 'button'"
-               @click.native="onClick"
-               @click="onClick"
                @keyup.enter="onClick"
-               @mouseover="onMouseover"
-               @mouseleave="onMouseleave"
                ref="item">
         <div class="m-navbar-item__text"
              :class="{ 'pp--is-nowrap': shouldNotWrap }">

--- a/packages/modul-components/src/components/navbar/navbar-item/navbar-item.ts
+++ b/packages/modul-components/src/components/navbar/navbar-item/navbar-item.ts
@@ -159,6 +159,10 @@ export class MNavbarItem extends ModulVue {
         return !this.multiline && this.parentNavbar ? this.parentNavbar.multiline : this.multiline;
     }
 
+    public get isRouterLink(): boolean {
+        return Boolean(this.url) && !this.disabled;
+    }
+
     public onClick(event: MouseEvent): void {
         if (!this.disabled && this.parentNavbar) {
             this.parentNavbar.onClick(event, this.value);


### PR DESCRIPTION
## Description
<!-- Décrivez brièvement les changements introduits par ce PR / Provide a small description of the changes introduced by this PR -->
Lorsque la balise `m-navbar-item` du composant est une `div`, event `@click.native="function()"` ne fonctionne pas.

![image](https://user-images.githubusercontent.com/29067208/90027167-3ae47300-dc86-11ea-905d-b5591887a85d.png)

## Types de changements
<!--- Indiquez ici quels types de modifications votre code introduit / Indicated here what types of changes does your code introduce -->
- [x] Correction de bug (sans `breaking change`)
- [ ] Amélioration (ajout par example une nouvelle propriété, évènement, slot ou méthode à un composant existant sans `breaking change`)
- [ ] Nouvelle fonctionalité (nouveau composant, directive, filtre ou service)
- [ ] Breaking change (modification à une fonctionnalités existante qui nécessite une migration *remplir la section release note*)
- [ ] Refactoring/ménage (sans `breaking change`)
- [ ] Documentation/storybook (changement à la documentation ou aux storybooks qui n'affecte aucun package)
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Comment cela peut-il être testé?
<!--- Décrivez comment vous avez testé vos modifications / Please describe how you tested your changes -->
- [ ] Test unitaire (un nouveau test unitaire à été fait)
- [x] Storybook
- [ ] Test manuel / Sandboxes
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Inclure cette section dans les release notes
<!-- Pour chaque breaking changes , inscrire la description du changement et les instructions pour la migration -->

## Liens internes
<!-- Si vous êtes un contributeur interne, ajouter les liens vers vos billets Jira. ou déploiement dans openshift -->

<!--  Merci d'avoir contribué! / Thanks for contributing! -->
