### PR TITLE
[m-select] Ajout props max-height sur la liste m-select

### DIFF
--- a/packages/modul-components/src/components/select/base-select/base-select.html
+++ b/packages/modul-components/src/components/select/base-select/base-select.html
@@ -52,7 +52,7 @@
             :aria-labelledby="controlId"
             aria-live="polite"
             :class="{ 'm--is-virutalScroll': virtualScroll }"
-            :style="{ minWidth: inputMaxWidth }">
+            :style="{ minWidth: inputMaxWidth, maxHeight: listMaxHeightProps }">
 
             <slot name="outer-items"
                   :items="items"

--- a/packages/modul-components/src/components/select/base-select/base-select.ts
+++ b/packages/modul-components/src/components/select/base-select/base-select.ts
@@ -3,6 +3,7 @@ import { POPUP_NAME as DIRECTIVE_POPUP_NAME } from '../../../directives/directiv
 import { MPopupDirective } from '../../../directives/popup/popup';
 import { InputWidth } from '../../../mixins/input-width/input-width';
 import { MediaQueries, MediaQueriesMixin } from '../../../mixins/media-queries/media-queries';
+import { REGEX_CSS_NUMBER_VALUE } from '../../../utils/props-validation/props-validation';
 import { ModulVue } from '../../../utils/vue/vue';
 import { POPUP_NAME } from '../../component-names';
 import { MPopup } from '../../popup/popup';
@@ -59,10 +60,16 @@ export class MBaseSelect extends ModulVue {
     @Prop({ default: false })
     public virtualScroll: boolean;
 
-    @Prop()
+    @Prop({
+        validator: (value: string) =>
+            REGEX_CSS_NUMBER_VALUE.test(value)
+    })
     public listMinWidth: string;
 
-    @Prop()
+    @Prop({
+        validator: (value: string) =>
+            REGEX_CSS_NUMBER_VALUE.test(value)
+    })
     public listMaxHeight: string;
 
     public $refs: {

--- a/packages/modul-components/src/components/select/base-select/base-select.ts
+++ b/packages/modul-components/src/components/select/base-select/base-select.ts
@@ -1,7 +1,7 @@
 import { Component, Emit, Prop, Watch } from 'vue-property-decorator';
-import { InputWidth } from '../../../mixins/input-width/input-width';
 import { POPUP_NAME as DIRECTIVE_POPUP_NAME } from '../../../directives/directive-names';
 import { MPopupDirective } from '../../../directives/popup/popup';
+import { InputWidth } from '../../../mixins/input-width/input-width';
 import { MediaQueries, MediaQueriesMixin } from '../../../mixins/media-queries/media-queries';
 import { ModulVue } from '../../../utils/vue/vue';
 import { POPUP_NAME } from '../../component-names';
@@ -62,6 +62,9 @@ export class MBaseSelect extends ModulVue {
     @Prop()
     public listMinWidth: string;
 
+    @Prop()
+    public listMaxHeight: string;
+
     public $refs: {
         items: HTMLUListElement;
         popup: MPopup;
@@ -80,6 +83,12 @@ export class MBaseSelect extends ModulVue {
 
     get ariaControls(): string {
         return this.controlId + '-controls';
+    }
+
+    get listMaxHeightProps(): string | undefined {
+        if (this.as<MediaQueriesMixin>().isMqMinS) {
+            return this.listMaxHeight;
+        }
     }
 
     @Emit('close')

--- a/packages/modul-components/src/components/select/select.html
+++ b/packages/modul-components/src/components/select/select.html
@@ -6,6 +6,7 @@
                :width="width"
                :max-width="maxWidth"
                :list-min-width="listMinWidth"
+               :list-max-height="listMaxHeight"
                :virtual-scroll="virtualScroll"
                @open="onOpen"
                @close="onClose"

--- a/packages/modul-components/src/components/select/select.ts
+++ b/packages/modul-components/src/components/select/select.ts
@@ -54,6 +54,9 @@ export class MSelect extends ModulVue {
     @Prop()
     public listMinWidth: string;
 
+    @Prop()
+    public listMaxHeight: string;
+
     id: string = `${SELECT_NAME}-${uuid.generate()}`;
     open: boolean = false;
 

--- a/packages/modul-components/src/components/select/select.ts
+++ b/packages/modul-components/src/components/select/select.ts
@@ -6,6 +6,7 @@ import { InputManagement } from '../../mixins/input-management/input-management'
 import { InputState } from '../../mixins/input-state/input-state';
 import { InputWidth } from '../../mixins/input-width/input-width';
 import { MediaQueries } from '../../mixins/media-queries/media-queries';
+import { REGEX_CSS_NUMBER_VALUE } from '../../utils/props-validation/props-validation';
 import uuid from '../../utils/uuid/uuid';
 import { ModulVue } from '../../utils/vue/vue';
 import { I18N_NAME, ICON_BUTTON_NAME, ICON_NAME, INPUT_STYLE_NAME, SELECT_NAME, VALIDATION_MESSAGE_NAME } from '../component-names';
@@ -54,7 +55,10 @@ export class MSelect extends ModulVue {
     @Prop()
     public listMinWidth: string;
 
-    @Prop()
+    @Prop({
+        validator: (value: string) =>
+            REGEX_CSS_NUMBER_VALUE.test(value)
+    })
     public listMaxHeight: string;
 
     id: string = `${SELECT_NAME}-${uuid.generate()}`;

--- a/src/storybook/src/modul-components/components/select/__snapshots__/select.stories.ts.snap
+++ b/src/storybook/src/modul-components/components/select/__snapshots__/select.stories.ts.snap
@@ -1827,6 +1827,120 @@ exports[`Storyshots modul-components|m-select Label Up 1`] = `
 </div>
 `;
 
+exports[`Storyshots modul-components|m-select List Max Height 1`] = `
+<div
+  class="m-base-select"
+  style="width: 100%; max-width: 288px;"
+>
+  <div
+    class="m-base-select__popup"
+  >
+    <div
+      class="m-select"
+      style="width: 100%; max-width: regular;"
+      tabindex="0"
+    >
+      <div
+        class="m-input-style m--has-cursor-pointer m--is-tag-default"
+        style="width: 100%; margin-top: 10px;"
+      >
+        <div
+          class="m-input-style__main"
+        >
+          <div
+            class="m-input-style__body"
+          >
+            <span
+              class="m-input-style__label"
+              style="z-index: -1;"
+            >
+              <span
+                class="m-input-style__text"
+              />
+            </span>
+             
+            <div
+              class="m-input-style__input"
+            >
+              <div
+                class="m-input-style__prefix"
+              />
+               
+              <div
+                class="m-input-style__content"
+              >
+                <div>
+                  <input
+                    readonly="readonly"
+                    tabindex="-1"
+                  />
+                </div>
+                 
+                <!---->
+                 
+                <!---->
+              </div>
+               
+              <div
+                class="m-input-style__suffix"
+              >
+                 
+                <!---->
+              </div>
+            </div>
+          </div>
+           
+          <div
+            class="m-input-style__append"
+          >
+            <!---->
+             
+            <div
+              class="m-select__arrow"
+            >
+              <svg
+                aria-hidden="true"
+                class="m-icon m-select__arrow__icon"
+                height="12px"
+                width="12px"
+              >
+                <!---->
+                 
+                <use
+                  aria-hidden="true"
+                  class=""
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+   
+  <div
+    class="m-validation-message m-select__validation-message"
+  >
+    <!---->
+     
+    <!---->
+  </div>
+   
+  <div
+    class="m-popup"
+  >
+    <div
+      class="m-popper"
+    >
+       
+      <!---->
+    </div>
+     
+    <!---->
+  </div>
+</div>
+`;
+
 exports[`Storyshots modul-components|m-select Long Option Menu 1`] = `
 <div
   class="m-base-select"

--- a/src/storybook/src/modul-components/components/select/select.stories.ts
+++ b/src/storybook/src/modul-components/components/select/select.stories.ts
@@ -5,7 +5,7 @@ import { MSelectItem } from '@ulaval/modul-components/dist/components/select/sel
 import { InputMaxWidth } from '@ulaval/modul-components/dist/mixins/input-width/input-width';
 import { modulComponentsHierarchyRootSeparator } from '../../../utils';
 
-const OPTIONS: string[] = ['apple', 'banana', 'patate', 'tomato', 'avocados', 'etc'];
+const OPTIONS: string[] = ['apple', 'banana', 'patate', 'tomato', 'avocados', 'orange', 'cherry', 'grape', 'lemon', 'peach', 'pineapple', 'etc'];
 const LONG_OPTIONS: string[] = ['apple juice', 'banana', 'patate', 'tomato', 'avocados', 'A fruit with a very long word for testing'];
 
 
@@ -245,6 +245,14 @@ export const disabledItemSelectedWithLabelClearable = () => ({
         options: OPTIONS
     }),
     template: `<m-select :options="options" :disabled="true" label="Fruits" :clearable="true" v-model="model" ></m-select>`
+});
+
+export const listMaxHeight = () => ({
+    data: () => ({
+        options: OPTIONS,
+        model: ''
+    }),
+    template: `<m-select v-model="model" :options="options" list-max-height="450px" ></m-select>`
 });
 
 export const withItemsSlot = () => ({


### PR DESCRIPTION
<!--
Veuillez consulter les directives de contribution / Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Content can be written in English or in French
-->

## Description
Ajout d'une props list-max-height sur le m-base-select et le m-select pour pouvoir paramétrer la hauteur de la liste ouverte

## Types de changements
<!--- Indiquez ici quels types de modifications votre code introduit / Indicated here what types of changes does your code introduce -->
- [ ] Correction de bug (sans `breaking change`)
- [x] Amélioration (ajout par example une nouvelle propriété, évènement, slot ou méthode à un composant existant sans `breaking change`)
- [ ] Nouvelle fonctionalité (nouveau composant, directive, filtre ou service)
- [ ] Breaking change (modification à une fonctionnalités existante qui nécessite une migration *remplir la section release note*)
- [ ] Refactoring/ménage (sans `breaking change`)
- [ ] Documentation/storybook (changement à la documentation ou aux storybooks qui n'affecte aucun package)
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Comment cela peut-il être testé?
<!--- Décrivez comment vous avez testé vos modifications / Please describe how you tested your changes -->
- [ ] Test unitaire (un nouveau test unitaire à été fait)
- [x] Storybook
- [ ] Test manuel / Sandboxes
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Liens internes
[ENA2-11471](https://jira.dti.ulaval.ca/browse/ENA2-11471)

<!--  Merci d'avoir contribué! / Thanks for contributing! -->
