### PR TITLE
m-empty-area: Text align with display-mode='inline'

### DIFF
--- a/packages/modul-components/src/components/empty-area/empty-area.scss
+++ b/packages/modul-components/src/components/empty-area/empty-area.scss
@@ -53,9 +53,14 @@
             justify-content: center;
         }
 
+        &__title-area {
+            text-align: center;
+        }
+
         &__icon {
             + .m-empty-area__title-area {
                 margin-left: $m-spacing--s  * 1.5;
+                text-align: left;
             }
         }
     }

--- a/packages/modul-components/src/components/responsive-table/table-group/table-group.scss
+++ b/packages/modul-components/src/components/responsive-table/table-group/table-group.scss
@@ -4,7 +4,7 @@
 @mixin row-highlighted-on-hover() {
     &.m--has-row-highlighted-on-hover.m--has-row-highlighted-on-hover {
         &:not(.m--is-disabled) {
-            tr:not(.m-table-group__header):hover {
+            tr:not(.m-table-group__header):not(.m-table-empty-row):hover {
                 background: $m-color--interactive-lightest;
             }
         }
@@ -184,7 +184,7 @@
     @include default-first-column-fixed();
 
     &.m--has-row-highlighted-on-hover {
-        &:not(.m--is-disabled) tr:not(.m-table-group__header):hover {
+        &:not(.m--is-disabled) tr:not(.m-table-group__header):not(.m-table-empty-row):hover {
             .m-table-group__cell:first-child {
                 background: $m-color--interactive-lightest;
             }


### PR DESCRIPTION
## Description
<!-- Décrivez brièvement les changements introduits par ce PR / Provide a small description of the changes introduced by this PR -->
1- Lorsque le composant `m-empty-area` à la prop `display-mode="inline"` et aucune icone, il faut appliquer le style `text-align: center;` sur le titre et sous-titre.
2- Retirer l'effet de survol du sur le `m-empty-area` dans un `m-table-empty-row`
## Types de changements
<!--- Indiquez ici quels types de modifications votre code introduit / Indicated here what types of changes does your code introduce -->
- [x] Correction de bug (sans `breaking change`)
- [ ] Amélioration (ajout par example une nouvelle propriété, évènement, slot ou méthode à un composant existant sans `breaking change`)
- [ ] Nouvelle fonctionalité (nouveau composant, directive, filtre ou service)
- [ ] Breaking change (modification à une fonctionnalités existante qui nécessite une migration *remplir la section release note*)
- [ ] Refactoring/ménage (sans `breaking change`)
- [ ] Documentation/storybook (changement à la documentation ou aux storybooks qui n'affecte aucun package)
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Comment cela peut-il être testé?
<!--- Décrivez comment vous avez testé vos modifications / Please describe how you tested your changes -->
- [ ] Test unitaire (un nouveau test unitaire à été fait)
- [ ] Storybook
- [ ] Test manuel / Sandboxes
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Inclure cette section dans les release notes
<!-- Pour chaque breaking changes , inscrire la description du changement et les instructions pour la migration -->

## Liens internes
<!-- Si vous êtes un contributeur interne, ajouter les liens vers vos billets Jira. ou déploiement dans openshift -->

<!--  Merci d'avoir contribué! / Thanks for contributing! -->
