### PR TITLE
Feature/ena2 7453 fleches tri colonne

### DIFF
--- a/packages/modul-components/src/components/table/table.ts
+++ b/packages/modul-components/src/components/table/table.ts
@@ -184,7 +184,7 @@ export class MTable extends ModulVue {
 
     public getColumnSortIcon(columnTable: MColumnTable): string {
         if (columnTable.sortDirection) {
-            return 'm-svg__arrow-thin--up'; // CSS rotate transform animation takes care of the arrow position
+            return 'm-svg__arrow-thin--down'; // CSS rotate transform animation takes care of the arrow position
         } else {
             return columnTable.defaultSortDirection === MColumnSortDirection.Dsc ? 'm-svg__arrow-thin--up' : 'm-svg__arrow-thin--down';
         }

--- a/packages/modul-components/src/components/table/table.ts
+++ b/packages/modul-components/src/components/table/table.ts
@@ -186,7 +186,7 @@ export class MTable extends ModulVue {
         if (columnTable.sortDirection) {
             return 'm-svg__arrow-thin--up'; // CSS rotate transform animation takes care of the arrow position
         } else {
-            return columnTable.defaultSortDirection === MColumnSortDirection.Dsc ? 'm-svg__arrow-thin--down' : 'm-svg__arrow-thin--up';
+            return columnTable.defaultSortDirection === MColumnSortDirection.Dsc ? 'm-svg__arrow-thin--up' : 'm-svg__arrow-thin--down';
         }
     }
 


### PR DESCRIPTION
## Description
Inverser la direction des flèches dans le tri des colonnes du m-table

## Types de changements
- [ ] Correction de bug (sans `breaking change`)
- [x] Amélioration (ajout par example une nouvelle propriété, évènement, slot ou méthode à un composant existant sans `breaking change`)
- [ ] Nouvelle fonctionalité (nouveau composant, directive, filtre ou service)
- [ ] Breaking change (modification à une fonctionnalités existante qui nécessite une migration *remplir la section release note*)
- [ ] Refactoring/ménage (sans `breaking change`)
- [ ] Documentation/storybook (changement à la documentation ou aux storybooks qui n'affecte aucun package)
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Comment cela peut-il être testé?
- [ ] Test unitaire (un nouveau test unitaire à été fait)
- [ ] Storybook
- [x] Test manuel / Sandboxes
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Inclure cette section dans les release notes
Les flèches seront inversées dans toutes les applications qui utilisent Modul. D'après ce que JP Goydadin dit dans le billet, c'est que ça a été approuvé par Jean-Philippe Marois.

## Liens internes
https://jira.dti.ulaval.ca/browse/ENA2-7453?filter=-1

<!--  Merci d'avoir contribué! / Thanks for contributing! -->
