### PR TITLE
Given m-message-page it's own state ENUM

### DIFF
--- a/packages/modul-components/src/components/message-page/message-page.ts
+++ b/packages/modul-components/src/components/message-page/message-page.ts
@@ -6,7 +6,6 @@ import { ModulVue } from '../../utils/vue/vue';
 import { ICON_NAME, LINK_NAME, MESSAGE_PAGE_NAME, SVG_NAME } from '../component-names';
 import { MIcon } from '../icon/icon';
 import { MLink } from '../link/link';
-import { MMessageState } from '../message/message';
 import { MSvg } from './../svg/svg';
 import WithRender from './message-page.html?style=./message-page.scss';
 
@@ -35,6 +34,13 @@ export enum MMessagePageImageSize {
     Small = '76px'
 }
 
+export enum MMessagePageState {
+    Information = 'information',
+    Warning = 'warning',
+    Confirmation = 'confirmation',
+    Error = 'error'
+}
+
 @WithRender
 @Component({
     components: {
@@ -48,10 +54,10 @@ export class MMessagePage extends ModulVue {
     @Prop({
         default: 'error',
         validator: value =>
-            value === MMessageState.Information ||
-            value === MMessageState.Warning ||
-            value === MMessageState.Confirmation ||
-            value === MMessageState.Error
+            value === MMessagePageState.Information ||
+            value === MMessagePageState.Warning ||
+            value === MMessagePageState.Confirmation ||
+            value === MMessagePageState.Error
     })
     public state: string;
 
@@ -117,19 +123,19 @@ export class MMessagePage extends ModulVue {
     }
 
     public get isStateInformation(): boolean {
-        return this.state === MMessageState.Information;
+        return this.state === MMessagePageState.Information;
     }
 
     public get isStateWarning(): boolean {
-        return this.state === MMessageState.Warning;
+        return this.state === MMessagePageState.Warning;
     }
 
     public get isStateError(): boolean {
-        return this.state === MMessageState.Error;
+        return this.state === MMessagePageState.Error;
     }
 
     public get isStateConfirmation(): boolean {
-        return this.state === MMessageState.Confirmation;
+        return this.state === MMessagePageState.Confirmation;
     }
 
     public get iconNameProp(): string {
@@ -137,11 +143,11 @@ export class MMessagePage extends ModulVue {
             return this.iconName;
         } else {
             switch (this.state) {
-                case MMessageState.Confirmation:
+                case MMessagePageState.Confirmation:
                     return ModulIconName.ConfirmationWhiteFilled;
-                case MMessageState.Information:
+                case MMessagePageState.Information:
                     return ModulIconName.InformationWhiteFilled;
-                case MMessageState.Warning:
+                case MMessagePageState.Warning:
                     return ModulIconName.WarningWhiteFilled;
                 default:
                     return ModulIconName.ErrorWhiteFilled;

--- a/packages/modul-components/src/components/message-page/message-page.ts
+++ b/packages/modul-components/src/components/message-page/message-page.ts
@@ -59,7 +59,7 @@ export class MMessagePage extends ModulVue {
             value === MMessagePageState.Confirmation ||
             value === MMessagePageState.Error
     })
-    public state: string;
+    public state: MMessagePageState;
 
     @Prop({
         default: MMessagePageSkin.Default,

--- a/packages/modul-components/src/lib.ts
+++ b/packages/modul-components/src/lib.ts
@@ -70,6 +70,7 @@ export * from './components/link/link';
 export * from './components/list-item/list-item';
 export * from './components/menu/menu';
 export * from './components/menu/menu-item/menu-item';
+export * from './components/message-page/message-page';
 export * from './components/message/message';
 export * from './components/modal/modal';
 export * from './components/moneyfield/moneyfield';


### PR DESCRIPTION
<!--
Veuillez consulter les directives de contribution / Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Content can be written in English or in French
-->

## Description
<!-- Décrivez brièvement les changements introduits par ce PR / Provide a small description of the changes introduced by this PR -->
Les composantes m-message et m-message-page partagent le même ENUM pour la définition de l'état (confirmation, info, warn, error). 

Ce partage d'énum peut entrainer un cycle dans les importations. La solution a donc été de définir un énum d'état pour m-message.

La solution optimale serait d'extraire cet énum d'état et que toutes les composantes le réquérant l'importe (centraliserait les sources de changement et éviterait la répétition).

## Types de changements
<!--- Indiquez ici quels types de modifications votre code introduit / Indicated here what types of changes does your code introduce -->
- [x] Correction de bug (sans `breaking change`)
- [x] Amélioration (ajout par example une nouvelle propriété, évènement, slot ou méthode à un composant existant sans `breaking change`)
- [ ] Nouvelle fonctionalité (nouveau composant, directive, filtre ou service)
- [ ] Breaking change (modification à une fonctionnalités existante qui nécessite une migration *remplir la section release note*)
- [ ] Refactoring/ménage (sans `breaking change`)
- [ ] Documentation/storybook (changement à la documentation ou aux storybooks qui n'affecte aucun package)
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Comment cela peut-il être testé?
<!--- Décrivez comment vous avez testé vos modifications / Please describe how you tested your changes -->
- [ ] Test unitaire (un nouveau test unitaire à été fait)
- [ ] Storybook
- [ ] Test manuel / Sandboxes
- [x] Autre
<!-- si vous avez sélectionner autre, préciser ici -->
Le seul test possible est d'avoir un projet créant le cycle de d'import

## Inclure cette section dans les release notes
<!-- Pour chaque breaking changes , inscrire la description du changement et les instructions pour la migration -->
Creation of an ENUM specific for the configuration of the component `m-message-page` (`MMessagePageState`). The current one (`m-message-state`) can still be used but it might create an import cycle while using `m-dialog` + `m-message` + `m-message-page`

## Liens internes
<!-- Si vous êtes un contributeur interne, ajouter les liens vers vos billets Jira. ou déploiement dans openshift -->
https://jira.dti.ulaval.ca/browse/ENA2-12611

<!--  Merci d'avoir contribué! / Thanks for contributing! -->
