### PR TITLE
Use default i18n formatting w/multi-select 

### DIFF
--- a/packages/modul-components/src/components/multi-select/multi-select.html
+++ b/packages/modul-components/src/components/multi-select/multi-select.html
@@ -53,7 +53,7 @@
                                        @delete="onDeleteAll()">
                             <template v-slot:default>
                                 <slot name="chips-all">
-                                    {{ textNumberOfItemsSelected }}
+                                    {{ textNumberOfSelectedItems }}
                                 </slot>
                             </template>
                         </m-chip-delete>

--- a/packages/modul-components/src/components/multi-select/multi-select.html
+++ b/packages/modul-components/src/components/multi-select/multi-select.html
@@ -74,7 +74,7 @@
                         </m-chip-delete>
                         <span class="m-multi-select__more">
                             <slot name="more">
-                                {{ textNumberOfItemsSelectedMore }}
+                                {{ textNumberOfUnselectedItemsLeft }}
                             </slot>
                         </span>
                     </template>

--- a/packages/modul-components/src/components/multi-select/multi-select.html
+++ b/packages/modul-components/src/components/multi-select/multi-select.html
@@ -53,8 +53,7 @@
                                        @delete="onDeleteAll()">
                             <template v-slot:default>
                                 <slot name="chips-all">
-                                    <m-i18n k="m-multi-select:all-selected"
-                                            :params="[numberOfItemsSelected]"></m-i18n>
+                                    {{ textNumberOfItemsSelected }}
                                 </slot>
                             </template>
                         </m-chip-delete>
@@ -75,8 +74,7 @@
                         </m-chip-delete>
                         <span class="m-multi-select__more">
                             <slot name="more">
-                                <m-i18n k="m-multi-select:more"
-                                        :params="[numberOfItemsSelected - maxVisibleChips]"></m-i18n>
+                                {{ textNumberOfItemsSelectedMore }}
                             </slot>
                         </span>
                     </template>

--- a/packages/modul-components/src/components/multi-select/multi-select.ts
+++ b/packages/modul-components/src/components/multi-select/multi-select.ts
@@ -139,7 +139,7 @@ export class MMultiSelect extends ModulVue {
         return this.$i18n.translate('m-multi-select:all-selected', [this.numberOfItemsSelected], undefined, undefined,false, FormatMode.Default);
     }
 
-    get textNumberOfItemsSelectedMore(): string {
+    get textNumberOfUnselectedItemsLeft(): string {
         return this.$i18n.translate('m-multi-select:more', [this.numberOfItemsSelected - this.maxVisibleChips], undefined, undefined,false, FormatMode.Default);
     }
 

--- a/packages/modul-components/src/components/multi-select/multi-select.ts
+++ b/packages/modul-components/src/components/multi-select/multi-select.ts
@@ -135,7 +135,7 @@ export class MMultiSelect extends ModulVue {
         return -1;
     }
 
-    get textNumberOfItemsSelected(): string {
+    get textNumberOfSelectedItems(): string {
         return this.$i18n.translate('m-multi-select:all-selected', [this.numberOfItemsSelected], undefined, undefined,false, FormatMode.Default);
     }
 

--- a/packages/modul-components/src/components/multi-select/multi-select.ts
+++ b/packages/modul-components/src/components/multi-select/multi-select.ts
@@ -1,11 +1,11 @@
 import { PluginObject } from 'vue';
 import Component from 'vue-class-component';
 import { Emit, Model, Prop, Watch } from 'vue-property-decorator';
-import { FormatMode } from '../../../dist/utils/i18n/i18n';
 import { InputLabel } from '../../mixins/input-label/input-label';
 import { InputState, InputStateMixin } from '../../mixins/input-state/input-state';
 import { InputWidth } from '../../mixins/input-width/input-width';
 import { MediaQueries } from '../../mixins/media-queries/media-queries';
+import { FormatMode } from '../../utils/i18n/i18n';
 import uuid from '../../utils/uuid/uuid';
 import { ModulVue } from '../../utils/vue/vue';
 import { I18N_NAME, ICON_NAME, INPUT_STYLE_NAME, MULTI_SELECT_NAME, VALIDATION_MESSAGE_NAME } from '../component-names';

--- a/packages/modul-components/src/components/multi-select/multi-select.ts
+++ b/packages/modul-components/src/components/multi-select/multi-select.ts
@@ -136,11 +136,11 @@ export class MMultiSelect extends ModulVue {
     }
 
     get textNumberOfItemsSelected(): string {
-        return this.$i18n.translate('m-multi-select:all-selected', [this.numberOfItemsSelected], undefined, undefined,false, FormatMode.Default)
+        return this.$i18n.translate('m-multi-select:all-selected', [this.numberOfItemsSelected], undefined, undefined,false, FormatMode.Default);
     }
 
     get textNumberOfItemsSelectedMore(): string {
-        return this.$i18n.translate('m-multi-select:more', [this.numberOfItemsSelected - this.maxVisibleChips], undefined, undefined,false, FormatMode.Default)
+        return this.$i18n.translate('m-multi-select:more', [this.numberOfItemsSelected - this.maxVisibleChips], undefined, undefined,false, FormatMode.Default);
     }
 
     public toggle(): void {

--- a/packages/modul-components/src/components/multi-select/multi-select.ts
+++ b/packages/modul-components/src/components/multi-select/multi-select.ts
@@ -1,6 +1,7 @@
 import { PluginObject } from 'vue';
 import Component from 'vue-class-component';
 import { Emit, Model, Prop, Watch } from 'vue-property-decorator';
+import { FormatMode } from '../../../dist/utils/i18n/i18n';
 import { InputLabel } from '../../mixins/input-label/input-label';
 import { InputState, InputStateMixin } from '../../mixins/input-state/input-state';
 import { InputWidth } from '../../mixins/input-width/input-width';
@@ -132,6 +133,14 @@ export class MMultiSelect extends ModulVue {
             return 0;
         }
         return -1;
+    }
+
+    get textNumberOfItemsSelected(): string {
+        return this.$i18n.translate('m-multi-select:all-selected', [this.numberOfItemsSelected], undefined, undefined,false, FormatMode.Default)
+    }
+
+    get textNumberOfItemsSelectedMore(): string {
+        return this.$i18n.translate('m-multi-select:more', [this.numberOfItemsSelected - this.maxVisibleChips], undefined, undefined,false, FormatMode.Default)
     }
 
     public toggle(): void {


### PR DESCRIPTION
<!--
Veuillez consulter les directives de contribution / Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Content can be written in English or in French
-->

## Description
<!-- Décrivez brièvement les changements introduits par ce PR / Provide a small description of the changes introduced by this PR -->
Uses default formatting for the multiselect component selected items count. This fixes a case where the i18n formatting is different in a consumer project. Since this component uses the {0} parameters format, the translation is broken when using the Sprintf format (%(var)s).

## Types de changements
<!--- Indiquez ici quels types de modifications votre code introduit / Indicated here what types of changes does your code introduce -->
- [x] Correction de bug (sans `breaking change`)
- [ ] Amélioration (ajout par example une nouvelle propriété, évènement, slot ou méthode à un composant existant sans `breaking change`)
- [ ] Nouvelle fonctionalité (nouveau composant, directive, filtre ou service)
- [ ] Breaking change (modification à une fonctionnalités existante qui nécessite une migration *remplir la section release note*)
- [ ] Refactoring/ménage (sans `breaking change`)
- [ ] Documentation/storybook (changement à la documentation ou aux storybooks qui n'affecte aucun package)
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Comment cela peut-il être testé?
<!--- Décrivez comment vous avez testé vos modifications / Please describe how you tested your changes -->
- [ ] Test unitaire (un nouveau test unitaire à été fait)
- [x] Storybook
- [x] Test manuel / Sandboxes
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->
Imported in another project with different formatting.

## Inclure cette section dans les release notes
<!-- Pour chaque breaking changes , inscrire la description du changement et les instructions pour la migration -->

## Liens internes
<!-- Si vous êtes un contributeur interne, ajouter les liens vers vos billets Jira. ou déploiement dans openshift -->
No Jira ticket.

<!--  Merci d'avoir contribué! / Thanks for contributing! -->
