### PR TITLE
[ICONS/SVG] Uniformiser les traits de deux SVG

### DIFF
--- a/packages/modul-components/src/assets/icons/svg/clock.svg
+++ b/packages/modul-components/src/assets/icons/svg/clock.svg
@@ -1,6 +1,6 @@
-<svg id="m-svg__clock" xmlns="http://www.w3.org/2000/svg" viewBox="-1 -1 26 26">
-    <g stroke="currentColor" fill="none">
+<svg id="svg__clock" xmlns="http://www.w3.org/2000/svg" viewBox="-1 -1 26 26">
+    <g fill="none" stroke="currentColor">
         <circle cx="12" cy="12" r="11.5"/>
-        <polyline points="20.3,12 12,12 12,4.7 	"/>
+        <polyline stroke-linecap="round" points="20.3,12 12,12 12,4.7 	"/>
     </g>
 </svg>

--- a/packages/modul-components/src/assets/icons/svg/clock.svg
+++ b/packages/modul-components/src/assets/icons/svg/clock.svg
@@ -1,4 +1,4 @@
-<svg id="svg__clock" xmlns="http://www.w3.org/2000/svg" viewBox="-1 -1 26 26">
+<svg id="m-svg__clock" xmlns="http://www.w3.org/2000/svg" viewBox="-1 -1 26 26">
     <g fill="none" stroke="currentColor">
         <circle cx="12" cy="12" r="11.5"/>
         <polyline stroke-linecap="round" points="20.3,12 12,12 12,4.7 	"/>

--- a/packages/modul-components/src/assets/icons/svg/code-tag.svg
+++ b/packages/modul-components/src/assets/icons/svg/code-tag.svg
@@ -1,5 +1,7 @@
 <svg id="m-svg__code-tag" xmlns="http://www.w3.org/2000/svg" viewBox="-1 -1 26 26">
-    <polyline stroke="currentColor" fill="none" points="7.5,17.5 0.5,11.8 7.1,6.5 "/>
-    <polyline stroke="currentColor" fill="none" points="16.5,6.5 23.5,12.2 16.9,17.5 "/>
-    <line stroke="currentColor" x1="9.2" y1="18.5" x2="14.8" y2="5.5"/>
+    <g stroke="currentColor" stroke-linecap="round">
+        <polyline fill="none" points="7.5,17.5 0.5,11.8 7.1,6.5 "/>
+        <polyline fill="none" points="16.5,6.5 23.5,12.2 16.9,17.5 "/>
+        <line x1="9.2" y1="18.5" x2="14.8" y2="5.5"/>
+    </g>
 </svg>

--- a/src/storybook/src/modul-components/components/svg/svg-importation.ts
+++ b/src/storybook/src/modul-components/components/svg/svg-importation.ts
@@ -1,4 +1,3 @@
-
 import MSvgAddCircleFilled from '@ulaval/modul-components/dist/assets/icons/svg/add-circle-filled.svg';
 import MSvgAddCircle from '@ulaval/modul-components/dist/assets/icons/svg/add-circle.svg';
 import MSvgArrowDown from '@ulaval/modul-components/dist/assets/icons/svg/arrow--down.svg';


### PR DESCRIPTION

## Description
Les traits des deux SVG suivants ont été modifiés: `clock.svg` et `code-tag.svg`.
Le styles des traits de ces deux SVG n'étaient uniformes aux autres SVG de type icône.
La propriété `stroke-linecap="round"` a été ajouter sur les trait pour les arrondir.
Cette modification n'implique aucun breaking change.

Voir les icônes **clock** et **code-tag** dans cette story: 
http://localhost:8082/?path=/story/modul-components-m-svg-categories--default-story

## Types de changements
<!--- Indiquez ici quels types de modifications votre code introduit / Indicated here what types of changes does your code introduce -->
- [x] Correction de bug (sans `breaking change`)
- [ ] Amélioration (ajout par example une nouvelle propriété, évènement, slot ou méthode à un composant existant sans `breaking change`)
- [ ] Nouvelle fonctionalité (nouveau composant, directive, filtre ou service)
- [ ] Breaking change (modification à une fonctionnalités existante qui nécessite une migration *remplir la section release note*)
- [ ] Refactoring/ménage (sans `breaking change`)
- [ ] Documentation/storybook (changement à la documentation ou aux storybooks qui n'affecte aucun package)
- [ ] Autre

## Comment cela peut-il être testé?
<!--- Décrivez comment vous avez testé vos modifications / Please describe how you tested your changes -->
- [ ] Test unitaire (un nouveau test unitaire à été fait)
- [x] Storybook
- [ ] Test manuel / Sandboxes
- [ ] Autre
Voir les icônes **clock** et **code-tag** dans cette story: 
http://localhost:8082/?path=/story/modul-components-m-svg-categories--default-story

## Inclure cette section dans les release notes
<!-- Pour chaque breaking changes , inscrire la description du changement et les instructions pour la migration -->

## Liens internes
<!-- Si vous êtes un contributeur interne, ajouter les liens vers vos billets Jira. ou déploiement dans openshift -->

<!--  Merci d'avoir contribué! / Thanks for contributing! -->
