### PR TITLE
[m-periodpicker] toIsoString utilise la donnée "from" au lieu de "to"

### DIFF
--- a/packages/modul-components/src/components/periodpicker/periodpicker.ts
+++ b/packages/modul-components/src/components/periodpicker/periodpicker.ts
@@ -27,14 +27,14 @@ export class MDateRange {
     }
 
     get toIsoString(): string | undefined {
-        if (!this.from) {
+        if (!this.to) {
             return undefined;
         }
 
-        if (typeof this.from === 'string') {
-            return this.from.includes('T') ? this.from : new ModulDate(this.from).endOfDay().toISOString();
+        if (typeof this.to === 'string') {
+            return this.to.includes('T') ? this.to : new ModulDate(this.to).endOfDay().toISOString();
         } else {
-            return this.from.toISOString();
+            return this.to.toISOString();
         }
     }
 }


### PR DESCRIPTION
<!--
Veuillez consulter les directives de contribution / Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Content can be written in English or in French
-->

## Description
<!-- Décrivez brièvement les changements introduits par ce PR / Provide a small description of the changes introduced by this PR -->
Dans la class MDateRange, la méthode toIsoString utilise la donnée "from" au lieu de "to".

## Types de changements
<!--- Indiquez ici quels types de modifications votre code introduit / Indicated here what types of changes does your code introduce -->
- [x] Correction de bug (sans `breaking change`)
- [ ] Amélioration (ajout par example une nouvelle propriété, évènement, slot ou méthode à un composant existant sans `breaking change`)
- [ ] Nouvelle fonctionalité (nouveau composant, directive, filtre ou service)
- [ ] Breaking change (modification à une fonctionnalités existante qui nécessite une migration *remplir la section release note*)
- [ ] Refactoring/ménage (sans `breaking change`)
- [ ] Documentation/storybook (changement à la documentation ou aux storybooks qui n'affecte aucun package)
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Comment cela peut-il être testé?
<!--- Décrivez comment vous avez testé vos modifications / Please describe how you tested your changes -->
- [ ] Test unitaire (un nouveau test unitaire à été fait)
- [ ] Storybook
- [ ] Test manuel / Sandboxes
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Inclure cette section dans les release notes
<!-- Pour chaque breaking changes , inscrire la description du changement et les instructions pour la migration -->

## Liens internes
<!-- Si vous êtes un contributeur interne, ajouter les liens vers vos billets Jira. ou déploiement dans openshift -->

<!--  Merci d'avoir contribué! / Thanks for contributing! -->
