### PR TITLE
Ajouter une config optionnel pour ignorer paramsSerializer dans utils http

### DIFF
--- a/packages/modul-components/src/utils/http/http.ts
+++ b/packages/modul-components/src/utils/http/http.ts
@@ -121,7 +121,9 @@ export class HttpService implements RestAdapter {
             axiosConfig.data = config.data;
         }
 
-        axiosConfig.paramsSerializer = params => serializeParams(params);
+        if (!config.ignoreParamsSerializer) {
+            axiosConfig.paramsSerializer = params => serializeParams(params);
+        }
 
         return axiosConfig;
     }

--- a/packages/modul-components/src/utils/http/rest.ts
+++ b/packages/modul-components/src/utils/http/rest.ts
@@ -9,6 +9,7 @@ export interface RequestConfig {
     formParams?: any;
     data?: any;
     timeout?: number;
+    ignoreParamsSerializer?: boolean;
 }
 
 export interface RestAdapter {


### PR DESCRIPTION
## Description
Un paramètre a été ajouté dans l'interface RequestConfig pour rendre optionnel un changement dans axios config _paramsSerializer_.

## Types de changements
- [ ] Correction de bug (sans `breaking change`)
- [X] Amélioration (ajout par example une nouvelle propriété, évènement, slot ou méthode à un composant existant sans `breaking change`)
- [ ] Nouvelle fonctionalité (nouveau composant, directive, filtre ou service)
- [ ] Breaking change (modification à une fonctionnalités existante qui nécessite une migration *remplir la section release note*)
- [ ] Refactoring/ménage (sans `breaking change`)
- [ ] Documentation/storybook (changement à la documentation ou aux storybooks qui n'affecte aucun package)
- [ ] Autre

## Comment cela peut-il être testé?
- [ ] Test unitaire (un nouveau test unitaire à été fait)
- [ ] Storybook
- [X] Test manuel / Sandboxes
- [ ] Autre

## Inclure cette section dans les release notes
Ajouté une config optionnel pour ignorer paramsSerializer dans utils http