### PR TITLE
Hotfix/gestion focusin android dans fenetres

### DIFF
--- a/packages/modul-components/src/components/dialog/dialog.ts
+++ b/packages/modul-components/src/components/dialog/dialog.ts
@@ -88,8 +88,6 @@ export class MDialog extends ModulVue implements PortalMixinImpl {
         this.as<PortalMixin>().propOpen = true;
     }
 
-
-
     public doCustomPropOpen(value: boolean): boolean {
         return false;
     }

--- a/packages/modul-components/src/components/modal/modal.scss
+++ b/packages/modul-components/src/components/modal/modal.scss
@@ -198,20 +198,9 @@ $m-modal--max-width--s: 420px !default;
 
     &__footer {
         position: relative;
+        display: flex;
+        align-items: center;
         border-top: 1px solid $m-color--border;
-        animation: fadeIn 0.5s linear forwards;
         padding: var(--m-modal--footer-padding);
-    }
-
-    @keyframes fadeIn {
-        0% {
-            opacity: 0;
-            z-index: -1;
-        }
-
-        100% {
-            opacity: 1;
-            z-index: 1;
-        }
     }
 }

--- a/packages/modul-components/src/components/modal/modal.ts
+++ b/packages/modul-components/src/components/modal/modal.ts
@@ -123,20 +123,31 @@ export class MModal extends ModulVue implements PortalMixinImpl {
         return UserAgentUtil.isAndroid();
     }
 
-    private onFocusIn(): void {
-        if (this.isAndroid) {
+    private isFocusableTextBox(element: HTMLElement): boolean {
+        const type = element.getAttribute('type');
+        return (element.tagName === 'INPUT'
+            && type != 'checkbox'
+            && type != 'radio'
+            && type != 'button'
+            && type != 'reset'
+            && type != 'file') || element.tagName === 'TEXTAREA';
+    }
+
+    private onFocusIn(event: FocusEvent): void {
+        if (
+            this.isAndroid
+            && this.isFocusableTextBox(event.target as HTMLElement)
+        ) {
             this.hasKeyboard = true;
         }
     }
 
-    private onFocusOut(): void {
+    private onFocusOut(event: FocusEvent): void {
         if (!this.isAndroid) {
             return;
         }
 
-        setTimeout(() => {
-            this.hasKeyboard = false;
-        });
+        this.hasKeyboard = false;
     }
 }
 

--- a/packages/modul-components/src/components/modal/modal.ts
+++ b/packages/modul-components/src/components/modal/modal.ts
@@ -126,11 +126,11 @@ export class MModal extends ModulVue implements PortalMixinImpl {
     private isFocusableTextBox(element: HTMLElement): boolean {
         const type = element.getAttribute('type');
         return (element.tagName === 'INPUT'
-            && type != 'checkbox'
-            && type != 'radio'
-            && type != 'button'
-            && type != 'reset'
-            && type != 'file') || element.tagName === 'TEXTAREA';
+            && type !== 'checkbox'
+            && type !== 'radio'
+            && type !== 'button'
+            && type !== 'reset'
+            && type !== 'file') || element.tagName === 'TEXTAREA';
     }
 
     private onFocusIn(event: FocusEvent): void {

--- a/packages/modul-components/src/components/overlay/overlay.scss
+++ b/packages/modul-components/src/components/overlay/overlay.scss
@@ -31,6 +31,7 @@
         }
 
         &.m--is-leave-active {
+
             &,
             .m-overlay__article {
                 transition-duration: $m-transition-duration--xl;
@@ -121,20 +122,9 @@
 
     &__footer {
         border-top: $m-border-width--s solid $m-color--border;
-        animation: fadeIn 0.5s linear forwards;
     }
 
     &__save-button {
         margin-right: $m-spacing;
-    }
-
-    @keyframes fadeIn {
-        0% {
-            opacity: 0;
-        }
-
-        100% {
-            opacity: 1;
-        }
     }
 }

--- a/packages/modul-components/src/components/overlay/overlay.ts
+++ b/packages/modul-components/src/components/overlay/overlay.ts
@@ -71,11 +71,11 @@ export class MOverlay extends ModulVue {
     private isFocusableTextBox(element: HTMLElement): boolean {
         const type = element.getAttribute('type');
         return (element.tagName === 'INPUT'
-            && type != 'checkbox'
-            && type != 'radio'
-            && type != 'button'
-            && type != 'reset'
-            && type != 'file') || element.tagName === 'TEXTAREA';
+            && type !== 'checkbox'
+            && type !== 'radio'
+            && type !== 'button'
+            && type !== 'reset'
+            && type !== 'file') || element.tagName === 'TEXTAREA';
     }
 
     private onFocusIn(event: FocusEvent): void {

--- a/packages/modul-components/src/components/overlay/overlay.ts
+++ b/packages/modul-components/src/components/overlay/overlay.ts
@@ -68,20 +68,31 @@ export class MOverlay extends ModulVue {
         return UserAgentUtil.isAndroid();
     }
 
-    private onFocusIn(): void {
-        if (this.isAndroid) {
+    private isFocusableTextBox(element: HTMLElement): boolean {
+        const type = element.getAttribute('type');
+        return (element.tagName === 'INPUT'
+            && type != 'checkbox'
+            && type != 'radio'
+            && type != 'button'
+            && type != 'reset'
+            && type != 'file') || element.tagName === 'TEXTAREA';
+    }
+
+    private onFocusIn(event: FocusEvent): void {
+        if (
+            this.isAndroid
+            && this.isFocusableTextBox(event.target as HTMLElement)
+        ) {
             this.hasKeyboard = true;
         }
     }
 
-    private onFocusOut(): void {
+    private onFocusOut(event: FocusEvent): void {
         if (!this.isAndroid) {
             return;
         }
 
-        setTimeout(() => {
-            this.hasKeyboard = false;
-        });
+        this.hasKeyboard = false;
     }
 
     private handlesFocus(): boolean {


### PR DESCRIPTION
<!--
Veuillez consulter les directives de contribution / Please review the contribution guidelines: https://github.com/ulaval/modul-components/blob/develop/.github/CONTRIBUTING.md.
-->

<!--
Content can be written in English or in French
-->

## Description
Les changement concerne le `m-modal` et le `m-overlay`
- Retirer l'animation en fade appliqué sur le footer
- Modifier la position du footer dans le HTML seulement si l'appareil utilisé est un android et qu'un champ texte est focus dans la fenêtre.

## Types de changements
<!--- Indiquez ici quels types de modifications votre code introduit / Indicated here what types of changes does your code introduce -->
- [x] Correction de bug (sans `breaking change`)
- [ ] Amélioration (ajout par example une nouvelle propriété, évènement, slot ou méthode à un composant existant sans `breaking change`)
- [ ] Nouvelle fonctionalité (nouveau composant, directive, filtre ou service)
- [ ] Breaking change (modification à une fonctionnalités existante qui nécessite une migration *remplir la section release note*)
- [ ] Refactoring/ménage (sans `breaking change`)
- [ ] Documentation/storybook (changement à la documentation ou aux storybooks qui n'affecte aucun package)
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Comment cela peut-il être testé?
<!--- Décrivez comment vous avez testé vos modifications / Please describe how you tested your changes -->
- [ ] Test unitaire (un nouveau test unitaire à été fait)
- [ ] Storybook
- [ ] Test manuel / Sandboxes
- [ ] Autre
<!-- si vous avez sélectionner autre, préciser ici -->

## Inclure cette section dans les release notes
<!-- Pour chaque breaking changes , inscrire la description du changement et les instructions pour la migration -->

## Liens internes
<!-- Si vous êtes un contributeur interne, ajouter les liens vers vos billets Jira. ou déploiement dans openshift -->

<!--  Merci d'avoir contribué! / Thanks for contributing! -->
