### PR TITLE
m-accordion: Retirer le "preventDefault" appliqué sur l'événement "click" de l'entête du "m-accordion"

### DIFF
--- a/packages/modul-components/src/components/accordion/accordion.html
+++ b/packages/modul-components/src/components/accordion/accordion.html
@@ -1,5 +1,5 @@
 <div class="m-accordion"
-         :class="[
+     :class="[
             'm--is-' + propSkin,
             {
                 'm--is-closed': !propOpen,
@@ -21,7 +21,7 @@
          :tabindex="headerTabindex"
          :aria-disabled="propDisabled"
          ref="accordionHeader"
-         @click.prevent="toggleAccordion"
+         @click="toggleAccordion"
          @keyup.self.enter="toggleAccordion"
          @keydown.space="toggleAccordion">
         <div class="m-accordion__header-content">
@@ -43,24 +43,24 @@
         <!-- Replace v-if / else with keep-alive. -->
         <template v-if="!keepContentAlive">
             <div v-if="propOpen"
-                :id="idBodyWrap"
-                class="m-accordion__body-wrap"
-                role="region"
-                :aria-labelledby="propId">
+                 :id="idBodyWrap"
+                 class="m-accordion__body-wrap"
+                 role="region"
+                 :aria-labelledby="propId">
                 <div class="m-accordion__body"
-                    :class="classBody">
+                     :class="classBody">
                     <slot />
                 </div>
             </div>
         </template>
         <template v-else>
             <div v-show="propOpen"
-                :id="idBodyWrap"
-                class="m-accordion__body-wrap"
-                role="region"
-                :aria-labelledby="propId">
+                 :id="idBodyWrap"
+                 class="m-accordion__body-wrap"
+                 role="region"
+                 :aria-labelledby="propId">
                 <div class="m-accordion__body"
-                    :class="classBody">
+                     :class="classBody">
                     <slot />
                 </div>
             </div>

--- a/packages/modul-components/src/components/accordion/accordion.ts
+++ b/packages/modul-components/src/components/accordion/accordion.ts
@@ -206,20 +206,25 @@ export class MAccordion extends ModulVue implements AccordionGateway {
 
         const target: Element | null = (event.target as HTMLElement).closest(ACCORDION_CLOSEST_ELEMENTS);
 
-        if (!this.propDisabled && !target) {
-            const initialState: boolean = this.internalOpen;
 
-            if (
-                !this.internalOpen &&
-                this.internalGroupRef &&
-                this.internalGroupRef.concurrent
-            ) {
-                this.internalGroupRef.closeAllAccordions();
-            }
-
-            this.propOpen = !initialState;
-            this.emitClick(event);
+        if (this.propDisabled || target) {
+            return;
         }
+
+
+        const initialState: boolean = this.internalOpen;
+
+        if (
+            !this.internalOpen &&
+            this.internalGroupRef &&
+            this.internalGroupRef.concurrent
+        ) {
+            this.internalGroupRef.closeAllAccordions();
+        }
+
+        this.propOpen = !initialState;
+        this.emitClick(event);
+
     }
 
     protected mounted(): void {

--- a/src/storybook/src/modul-components/components/accordion/accordion.stories.ts
+++ b/src/storybook/src/modul-components/components/accordion/accordion.stories.ts
@@ -17,7 +17,7 @@ storiesOf(`${modulComponentsHierarchyRootSeparator}${ACCORDION_NAME}`, module)
     }))
 
     .add('header', () => ({
-        template: '<m-accordion><h3 class="mu-no-m" slot="header">Value specified in header slot for this example and all others to follow <a href="https://www.google.ca" target="_blank">GOOGLE</a></h3> Some Accordion Content</m-accordion>'
+        template: '<m-accordion><h3 class="mu-no-m" slot="header">Value specified in header slot for this example and all others to follow</h3> Some Accordion Content</m-accordion>'
     }))
     .add('id', () => ({
         template: '<m-accordion id="id123"><h3 class="mu-no-m" slot="header">An Accordion Title</h3> Some Accordion Content</m-accordion>'

--- a/src/storybook/src/modul-components/components/accordion/accordion.stories.ts
+++ b/src/storybook/src/modul-components/components/accordion/accordion.stories.ts
@@ -17,7 +17,7 @@ storiesOf(`${modulComponentsHierarchyRootSeparator}${ACCORDION_NAME}`, module)
     }))
 
     .add('header', () => ({
-        template: '<m-accordion><h3 class="mu-no-m" slot="header">Value specified in header slot for this example and all others to follow</h3> Some Accordion Content</m-accordion>'
+        template: '<m-accordion><h3 class="mu-no-m" slot="header">Value specified in header slot for this example and all others to follow <a href="https://www.google.ca" target="_blank">GOOGLE</a></h3> Some Accordion Content</m-accordion>'
     }))
     .add('id', () => ({
         template: '<m-accordion id="id123"><h3 class="mu-no-m" slot="header">An Accordion Title</h3> Some Accordion Content</m-accordion>'


### PR DESCRIPTION
Retirer le "preventDefault" appliqué sur l'événement "click" de l'entête du "m-accordion"