### PR TITLE
[breaking change] m-accordion: modifier padding et hauteur min de l'entête

### DIFF
--- a/packages/modul-components/src/components/accordion/accordion.scss
+++ b/packages/modul-components/src/components/accordion/accordion.scss
@@ -16,7 +16,7 @@ $m-accordion--color-default: $m-color-interactive !default;
         transition: padding-top $m-transition-duration ease;
         background: $m-color-grey-darkest;
 
-        &:not(.m--is-open) + .m-accordion {
+        &:not(.m--is-open)+.m-accordion {
             padding-top: $m-accordion--border-size;
         }
     }
@@ -31,17 +31,17 @@ $m-accordion--color-default: $m-color-interactive !default;
             text-decoration: none;
         }
 
-        .m-accordion.m--is-empty-content > &,
-        .m-accordion.m--is-disabled > & {
+        .m-accordion.m--is-empty-content>&,
+        .m-accordion.m--is-disabled>& {
             cursor: auto;
             outline: none;
         }
 
-        .m-accordion.m--is-dark > &,
-        .m-accordion.m--is-dark-b > &,
-        .m-accordion.m--is-default > & {
+        .m-accordion.m--is-dark>&,
+        .m-accordion.m--is-dark-b>&,
+        .m-accordion.m--is-default>& {
             position: relative;
-            min-height: 80px;
+            min-height: 64px;
 
             &::after {
                 position: absolute;
@@ -51,31 +51,35 @@ $m-accordion--color-default: $m-color-interactive !default;
             }
 
             &.m--has-padding {
-                padding: $m-space $m-space $m-space calc(#{$m-space} + #{$m-accordion--vertical-border-size});
+                padding: $m-space-sm $m-space $m-space-sm calc(#{$m-space-sm} + #{$m-accordion--vertical-border-size});
+
+                @media (min-width: $m-mq-min-sm) {
+                    padding-left: calc(#{$m-space} + #{$m-accordion--vertical-border-size});
+                }
             }
         }
 
-        .m-accordion.m--is-dark > &,
-        .m-accordion.m--is-default > & {
+        .m-accordion.m--is-dark>&,
+        .m-accordion.m--is-default>& {
             &::after {
                 background: $m-accordion--color-default;
             }
         }
 
-        .m-accordion.m--is-dark-b > & {
+        .m-accordion.m--is-dark-b>& {
             &::after {
                 background: $m-color-white;
                 transition: background-color 0.4s ease;
             }
         }
 
-        .m-accordion.m--is-dark-b.m--is-open > & {
+        .m-accordion.m--is-dark-b.m--is-open>& {
             &::after {
                 background: $m-color-ul-yellow;
             }
         }
 
-        .m-accordion.m--is-default > & {
+        .m-accordion.m--is-default>& {
             color: $m-color-text;
             background-color: $m-color-white;
             border-top: $m-accordion--border-size solid $m-accordion--border-color;
@@ -87,12 +91,12 @@ $m-accordion--color-default: $m-color-interactive !default;
             }
         }
 
-        .m-accordion.m--is-default + .m-accordion.m--is-default > & {
+        .m-accordion.m--is-default+.m-accordion.m--is-default>& {
             border-top: 0; // hide border-top on the next accordion
         }
 
-        .m-accordion.m--is-dark > &,
-        .m-accordion.m--is-dark-b > & {
+        .m-accordion.m--is-dark>&,
+        .m-accordion.m--is-dark-b>& {
             color: $m-color-white;
             background-color: $m-color-grey-darker;
             transition: border-size 0.5s ease;
@@ -104,8 +108,8 @@ $m-accordion--color-default: $m-color-interactive !default;
         }
 
         // when open, hide border-top on the next accordion
-        .m-accordion.m--is-dark.m--is-open + .m-accordion.m--is-dark &,
-        .m-accordion.m--is-dark-b.m--is-open + .m-accordion.m--is-dark-b & {
+        .m-accordion.m--is-dark.m--is-open+.m-accordion.m--is-dark &,
+        .m-accordion.m--is-dark-b.m--is-open+.m-accordion.m--is-dark-b & {
             border-top: 0;
         }
 
@@ -164,7 +168,11 @@ $m-accordion--color-default: $m-color-interactive !default;
         display: block;
 
         &:not(.m--is-left) {
-            margin-left: $m-space;
+            margin-left: $m-space-sm;
+
+            @media (min-width: $m-mq-min-sm) {
+                margin-left: $m-space;
+            }
         }
 
         &.m--is-left {
@@ -184,9 +192,9 @@ $m-accordion--color-default: $m-color-interactive !default;
 
     &__body-wrap {
 
-        .m-accordion.m--is-dark > &,
-        .m-accordion.m--is-dark-b > &,
-        .m-accordion.m--is-default > & {
+        .m-accordion.m--is-dark>&,
+        .m-accordion.m--is-dark-b>&,
+        .m-accordion.m--is-default>& {
             &.m--is-enter-to {
                 .m-accordion__body {
                     transform: translate(0, 0);
@@ -202,19 +210,19 @@ $m-accordion--color-default: $m-color-interactive !default;
                 }
             }
 
-            > .m-accordion__body {
+            >.m-accordion__body {
                 transition: opacity $m-transition-duration-lg ease, transform $m-transition-duration ease;
             }
         }
 
-        .m-accordion.m--is-default > & {
+        .m-accordion.m--is-default>& {
             color: $m-color-text;
             background-color: $m-color-white;
             border-bottom: 2px solid $m-color-border;
         }
 
-        .m-accordion.m--is-dark > &,
-        .m-accordion.m--is-dark-b > & {
+        .m-accordion.m--is-dark>&,
+        .m-accordion.m--is-dark-b>& {
             border-top: 2px solid $m-color-grey-darkest;
             color: $m-color-white;
             background: #303030;
@@ -225,33 +233,40 @@ $m-accordion--color-default: $m-color-interactive !default;
     &__body {
         &.m--has-padding {
 
-            .m-accordion.m--is-dark > .m-accordion__body-wrap > &,
-            .m-accordion.m--is-dark-b > .m-accordion__body-wrap > &,
-            .m-accordion.m--is-default > .m-accordion__body-wrap > & {
-                padding: $m-space $m-space $m-space calc(#{$m-space} + #{$m-accordion--vertical-border-size});
+            .m-accordion.m--is-dark>.m-accordion__body-wrap>&,
+            .m-accordion.m--is-dark-b>.m-accordion__body-wrap>&,
+            .m-accordion.m--is-default>.m-accordion__body-wrap>& {
+                padding: $m-space-md $m-space $m-space-md calc(#{$m-space-sm} + #{$m-accordion--vertical-border-size});
+
+
+
             }
 
-            .m-accordion.m--is-dark.m--has-icon-left > .m-accordion__body-wrap > &,
-            .m-accordion.m--is-dark-b.m--has-icon-left > .m-accordion__body-wrap > &,
-            .m-accordion.m--is-default.m--has-icon-left > .m-accordion__body-wrap > & {
-                padding-left: $m-space-2xl;
+            .m-accordion.m--is-dark.m--has-icon-left>.m-accordion__body-wrap>&,
+            .m-accordion.m--is-dark-b.m--has-icon-left>.m-accordion__body-wrap>&,
+            .m-accordion.m--is-default.m--has-icon-left>.m-accordion__body-wrap>& {
+                @media (min-width: $m-mq-min-sm) {
+                    padding-left: $m-space-2xl;
+                }
             }
 
-            .m-accordion.m--is-dark.m--has-icon-left.m--has-icon-large > .m-accordion__body-wrap > &,
-            .m-accordion.m--is-dark-b.m--has-icon-left.m--has-icon-large > .m-accordion__body-wrap > &,
-            .m-accordion.m--is-default.m--has-icon-left.m--has-icon-large > .m-accordion__body-wrap > & {
-                padding-left: calc(#{$m-space} * 2 + #{$m-accordion--icon-l-width} + #{$m-accordion--vertical-border-size});
+            .m-accordion.m--is-dark.m--has-icon-left.m--has-icon-large>.m-accordion__body-wrap>&,
+            .m-accordion.m--is-dark-b.m--has-icon-left.m--has-icon-large>.m-accordion__body-wrap>&,
+            .m-accordion.m--is-default.m--has-icon-left.m--has-icon-large>.m-accordion__body-wrap>& {
+                @media (min-width: $m-mq-min-sm) {
+                    padding-left: calc(#{$m-space} * 2 + #{$m-accordion--icon-l-width} + #{$m-accordion--vertical-border-size});
+                }
             }
 
-            .m-accordion.m--is-light > .m-accordion__body-wrap > & {
+            .m-accordion.m--is-light>.m-accordion__body-wrap>& {
                 padding-top: $m-space-xs;
             }
 
-            .m-accordion.m--is-light.m--has-icon-left > .m-accordion__body-wrap > & {
+            .m-accordion.m--is-light.m--has-icon-left>.m-accordion__body-wrap>& {
                 padding-left: 36px; // Magic number
             }
 
-            .m-accordion.m--is-light.m--has-icon-left.m--has-icon-large > .m-accordion__body-wrap > & {
+            .m-accordion.m--is-light.m--has-icon-left.m--has-icon-large>.m-accordion__body-wrap>& {
                 padding-left: 40px; // Magic number
             }
 


### PR DESCRIPTION
## Modifications effectués sur le composant `m-accordion`

### Entête
- La `min-height` de l'entête est passé de `80px` à `64px`
- Le `padding-top` et `padding-bottom` sont passés de `16px` à `12px`

### Corps
- Le `padding-top` et `padding-bottom` sont passés de `16px` à `24px`
- Lorsqu'il y a une icone à gauche
  - En version mobile
    - Le `padding-left` est passés de `calc(#{$m-space} + #{$m-accordion--vertical-border-size})` à `calc(#{$m-space-sm} + #{$m-accordion--vertical-border-size})`

