### PR TITLE
[breaking change] m-modal et m-overlay: uniformisation des niveaux de titre

### DIFF
--- a/packages/modul-components/src/components/modal/modal.scss
+++ b/packages/modul-components/src/components/modal/modal.scss
@@ -39,18 +39,6 @@ $m-modal--max-width--s: 420px !default;
             justify-content: center;
         }
 
-        h1,
-        h2,
-        h3,
-        h4,
-        h5,
-        h6 {
-            margin: 0;
-            font-weight: $m-font-weight-semi-bold;
-
-            @include m-font-size('h4');
-        }
-
         @include m-is-ie() {
             display: block;
         }
@@ -171,6 +159,14 @@ $m-modal--max-width--s: 420px !default;
         align-items: center;
         justify-content: var(--m-modal--header-justify-content);
         padding: var(--m-modal--header-padding);
+
+        h1,
+        h2 {
+            margin: 0;
+            font-weight: $m-font-weight-semi-bold;
+
+            @include m-font-size('h2');
+        }
     }
 
     &__close-button {
@@ -181,11 +177,11 @@ $m-modal--max-width--s: 420px !default;
         overflow-x: hidden;
         overflow-y: auto;
         position: relative;
-        flex: 1 1 auto;
+        flex: auto;
         width: 100%;
-        -webkit-overflow-scrolling: touch;
         min-height: var(--m-modal--min-height);
         padding: var(--m-modal--body-padding);
+        -webkit-overflow-scrolling: touch;
 
         @include m-scrollbar();
 

--- a/packages/modul-components/src/components/overlay/overlay.scss
+++ b/packages/modul-components/src/components/overlay/overlay.scss
@@ -84,26 +84,23 @@
         background-color: $m-color-grey-black;
 
         h1,
-        h2,
-        h3,
-        h4,
-        h5,
-        h6 {
+        h2 {
             margin: 0;
-            @include m-font-size('h2');
             font-weight: $m-font-weight-semi-bold;
+
+            @include m-font-size('h2');
         }
     }
 
     &__header-left {
-        flex: 1 1 auto;
+        flex: auto;
     }
 
     &__body {
         overflow-x: hidden;
         overflow-y: auto;
         position: relative;
-        flex: 1 1 auto;
+        flex: auto;
         width: 100%;
         min-height: 160px;
         -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
- Retirer les styles appliqués sur les balises h1 à h6 sur la classe parent `.modal__wrap`
- Dans l'entête des fenêtres modal et overlay, appliquer seulement des styles sur les titres h1 et h2