### PR TITLE
Fenêtres et popup: ajouter du padding-bottom en version mobile

### DIFF
--- a/packages/modul-components/src/components/dropdown/dropdown.scss
+++ b/packages/modul-components/src/components/dropdown/dropdown.scss
@@ -70,6 +70,12 @@ $m-dropdown--margin: $m-space-2xs !default;
         text-align: left;
         background: $m-color-white;
 
+        &.m-dropdown__list {
+            @media (max-width: $m-mq-max-sm) {
+                padding-bottom: $m-space-md;
+            }
+        }
+
         @media (min-width: $m-mq-min-sm) {
             max-height: 208px;
         }

--- a/packages/modul-components/src/components/modal/modal.scss
+++ b/packages/modul-components/src/components/modal/modal.scss
@@ -11,7 +11,7 @@ $m-modal--max-width--s: 420px !default;
         --m-modal--header-padding: #{ $m-space };
         --m-modal--header-justify-content: space-between;
         --m-modal--body-padding: #{ $m-space-xl  $m-space };
-        --m-modal--footer-padding: #{ $m-space };
+        --m-modal--footer-padding: #{ $m-space } #{ $m-space } #{ $m-space-lg };
 
         @media (min-width: $m-mq-min-sm) {
             --m-modal--header-padding: #{ $m-space $m-space-lg };
@@ -190,6 +190,12 @@ $m-modal--max-width--s: 420px !default;
         // deprecated
         &.m--has-no-padding {
             --m-modal--body-padding: 0;
+        }
+
+        &:last-child:not(.m--has-no-padding) {
+            @media (max-width: $m-mq-max-sm) {
+                padding-bottom: $m-space-3xl;
+            }
         }
     }
 

--- a/packages/modul-components/src/components/option/option.scss
+++ b/packages/modul-components/src/components/option/option.scss
@@ -41,13 +41,10 @@ $m-option-mixed-bgc--hover: rgba(0, 0, 0, 0.66);
         width: 100%;
         margin: 0;
         padding: 0;
+        list-style: none;
         overflow-x: hidden;
         overflow-y: auto;
-        border: 1px solid $m-color-border;
-        border-radius: $m-border-radius-sm;
-        background: $m-color-white;
-        box-shadow: $m-box-shadow;
-        list-style: none;
+        background-color: $m-color-white;
 
         &.m-option__list {
             @media (max-width: $m-mq-max-sm) {
@@ -57,6 +54,9 @@ $m-option-mixed-bgc--hover: rgba(0, 0, 0, 0.66);
 
         @media (min-width: $m-mq-min-sm) {
             max-height: 243px; // Magic number: height of 4 items
+            border: 1px solid $m-color-border;
+            border-radius: $m-border-radius-sm;
+            box-shadow: $m-box-shadow;
         }
 
         @include m-scrollbar();

--- a/packages/modul-components/src/components/option/option.scss
+++ b/packages/modul-components/src/components/option/option.scss
@@ -49,6 +49,12 @@ $m-option-mixed-bgc--hover: rgba(0, 0, 0, 0.66);
         box-shadow: $m-box-shadow;
         list-style: none;
 
+        &.m-option__list {
+            @media (max-width: $m-mq-max-sm) {
+                padding-bottom: $m-space-md;
+            }
+        }
+
         @media (min-width: $m-mq-min-sm) {
             max-height: 243px; // Magic number: height of 4 items
         }

--- a/packages/modul-components/src/components/overlay/overlay.scss
+++ b/packages/modul-components/src/components/overlay/overlay.scss
@@ -107,10 +107,22 @@
 
         @include m-scrollbar();
         @include m-box-padding();
+
+        &:last-child:not(.m--no-padding) {
+            @media (max-width: $m-mq-max-sm) {
+                padding-bottom: $m-space-3xl;
+            }
+        }
     }
 
     &__footer {
         border-top: $m-border-width-sm solid $m-color-border;
+
+        &:not(.m--no-padding) {
+            @media (max-width: $m-mq-max-sm) {
+                padding-bottom: $m-space-lg;
+            }
+        }
     }
 
     &__save-button {

--- a/packages/modul-components/src/components/select/base-select/base-select.scss
+++ b/packages/modul-components/src/components/select/base-select/base-select.scss
@@ -7,9 +7,15 @@
     &__list {
         margin: 0;
         padding: 0;
-        max-height: 80%;
+        list-style-type: none;
         overflow-x: hidden;
         overflow-y: hidden;
+
+        &.m-base-select__list {
+            @media (max-width: $m-mq-max-sm) {
+                padding-bottom: $m-space-md;
+            }
+        }
 
         @media (min-width: $m-mq-min-sm) {
             max-height: 208px;

--- a/packages/modul-components/src/components/sidebar/sidebar.scss
+++ b/packages/modul-components/src/components/sidebar/sidebar.scss
@@ -197,9 +197,21 @@
         user-select: text;
 
         @include m-scrollbar();
+
+        &:last-child:not(.m--no-padding) {
+            @media (max-width: $m-mq-max-sm) {
+                padding-bottom: $m-space-xl;
+            }
+        }
     }
 
     &__footer {
         padding: $m-space-sm $m-space;
+
+        &:not(.m--no-padding) {
+            @media (max-width: $m-mq-max-sm) {
+                padding-bottom: $m-space-lg;
+            }
+        }
     }
 }

--- a/packages/modul-components/src/components/tooltip/tooltip.scss
+++ b/packages/modul-components/src/components/tooltip/tooltip.scss
@@ -64,6 +64,10 @@ $m-tooltip--max-height: 280px !default;
         word-break: break-word;
         user-select: text;
 
+        @media (max-width: $m-mq-max-sm) {
+            padding-bottom: $m-space-xl;
+        }
+
         @media (min-width: $m-mq-min-sm) {
             max-height: var(--m-tooltip--max-height);
             width: $m-tooltip--width;


### PR DESCRIPTION
**Règle le problème suivant**
Sur un appareil mobile, la barre surlignée en jaune (voir la capture) est trop collée sur les boutons.

<img width="180" src="https://github.com/ulaval/modul/assets/29067208/76a1224e-8357-4a34-b1da-854090ed9ae1">

<img width="180" src="https://github.com/ulaval/modul/assets/29067208/d8e17de8-1b9b-4b3e-b2a0-be6aff789b83">
